### PR TITLE
[Design] ErItem 컴포넌트 스타일 수정

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErItem.jsx
+++ b/er-allimi/src/components/ersBoxes/ErItem.jsx
@@ -51,7 +51,7 @@ function ErItem() {
 }
 
 const StyledErItem = styled.div`
-  padding: 0.5rem 0;
+  padding: 0.5rem 0.3rem;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grayLighter};
 
   &:hover {
@@ -84,7 +84,7 @@ const Body = styled.div`
   }
 
   p {
-    font-size: 13px;
+    font-size: 12px;
     line-height: 1.5rem;
   }
 


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/86f948d1-cc95-486f-ad09-4f5ab03ac8c7)

## 작업 내용
- ErItem 컴포넌트에서 좌우로 약간 padding을 주고, 주소/전화번호 글자 크기를 줄임

## 논의할 부분