### PR TITLE
[Refactor] ErsBox에서 내부를 ErsContent 컴포넌트로 빼냄 & [Feat] ErsMovingBox 컴포넌트 구현 & [Feat] ErsBoxes에 ErsMovingBox 추가

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErItem.jsx
+++ b/er-allimi/src/components/ersBoxes/ErItem.jsx
@@ -78,11 +78,27 @@ const HpName = styled.h5`
   &:hover {
     text-decoration: underline;
   }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    font-size: 13px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    font-size: 12px;
+  }
 `;
 
 const ErClassName = styled.p`
   font-size: 11px;
   color: ${({ theme }) => theme.colors.gray};
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    font-size: 10px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    font-size: 9px;
+  }
 `;
 
 const Body = styled.div`
@@ -91,19 +107,32 @@ const Body = styled.div`
   grid-template-columns: repeat(2);
   align-content: center;
   margin-top: 0.5rem;
+  line-height: 1.5rem;
+  font-size: 12px;
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    line-height: 1.3rem;
+    font-size: 11px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    line-height: 1.2rem;
+    font-size: 10px;
+  }
 
   svg {
     margin-right: 0.2rem;
   }
 
   p {
-    font-size: 12px;
-    line-height: 1.5rem;
+    line-height: inherit;
+    font-size: inherit;
   }
 
   div {
     display: flex;
     align-items: center;
+    font-size: inherit;
   }
 
   div:nth-of-type(1) {
@@ -141,7 +170,6 @@ const Body = styled.div`
     }
 
     p {
-      font-size: 11px;
       font-weight: 500;
       color: ${({ theme }) => theme.colors.grayDark};
     }
@@ -149,6 +177,14 @@ const Body = styled.div`
     .highlight {
       font-size: 13px;
       font-weight: 700;
+
+      @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+        font-size: 12px;
+      }
+
+      @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+        font-size: 11px;
+      }
     }
   }
 `;

--- a/er-allimi/src/components/ersBoxes/ErsBox.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsBox.jsx
@@ -1,58 +1,15 @@
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import {
-  Box,
-  Button,
-  ErsList,
-  RadiusDropdown,
-  ErsPagination,
-} from '@components';
+import { Box, ErsContent } from '@components';
 
 function ErsBox({ className }) {
   const StyledErsBox = styled(Box)`
     height: calc(100vh - 200px);
   `;
 
-  const Title = styled.h2`
-    margin-bottom: 0.5rem;
-  `;
-
-  const Utils = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0.5rem;
-  `;
-
-  const SortingButtons = styled.div`
-    display: flex;
-    align-items: center;
-
-    button {
-      margin-right: 0.5rem;
-    }
-  `;
-
-  const MarginTopPagination = styled(ErsPagination)`
-    margin-top: 0.5rem;
-  `;
-
   return (
     <StyledErsBox className={className}>
-      <Title>내 위치 주변 응급실 (15)</Title>
-      <Utils>
-        <SortingButtons>
-          <Button color="gray" round="lg">
-            거리순
-          </Button>
-          <Button color="gray" round="lg" outline>
-            가용 병상 개수 순
-          </Button>
-        </SortingButtons>
-        <RadiusDropdown />
-      </Utils>
-      <ErsList />
-      <MarginTopPagination />
+      <ErsContent />
     </StyledErsBox>
   );
 }

--- a/er-allimi/src/components/ersBoxes/ErsContent.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsContent.jsx
@@ -1,0 +1,97 @@
+import styled from '@emotion/styled';
+import { Button, ErsList, RadiusDropdown, ErsPagination } from '@components';
+
+function ErsContent() {
+  const StyledErsContent = styled.div`
+    width: 100%;
+    height: 100%;
+
+    @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+      height: calc(100% - 28px);
+    }
+  `;
+
+  const Title = styled.h2`
+    margin-bottom: 0.5rem;
+  `;
+
+  const Utils = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+  `;
+
+  const SortingButtons = styled.div`
+    display: flex;
+    align-items: center;
+
+    button {
+      margin-right: 0.5rem;
+
+      @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+        font-size: 12px;
+      }
+
+      @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+        font-size: 11px;
+      }
+    }
+  `;
+
+  const StyledRadiusDropdown = styled(RadiusDropdown)`
+    @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+      font-size: 12px;
+    }
+
+    @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+      font-size: 11px;
+    }
+  `;
+
+  const StyledErsList = styled(ErsList)`
+    height: calc(100% - 100px);
+    overflow-y: scroll;
+
+    @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+      height: calc(100% - 100px + 5px);
+    }
+
+    @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+      height: calc(100% - 100px + 10px);
+    }
+  `;
+
+  const MarginTopPagination = styled(ErsPagination)`
+    margin-top: 0.5rem;
+
+    @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+      font-size: 12px;
+    }
+
+    @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+      font-size: 11px;
+    }
+  `;
+
+  return (
+    <StyledErsContent>
+      <Title>내 위치 주변 응급실 (15)</Title>
+      <Utils>
+        <SortingButtons>
+          <Button color="gray" round="lg">
+            거리순
+          </Button>
+          <Button color="gray" round="lg" outline>
+            가용 병상 개수 순
+          </Button>
+        </SortingButtons>
+        <StyledRadiusDropdown />
+      </Utils>
+      <StyledErsList />
+      <MarginTopPagination />
+    </StyledErsContent>
+  );
+}
+
+export default ErsContent;

--- a/er-allimi/src/components/ersBoxes/ErsList.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsList.jsx
@@ -1,19 +1,18 @@
-import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
 import { ErItem } from '@components';
 
-function ErsList() {
+function ErsList({ className }) {
   const renderErItems = Array(15)
     .fill(0)
     .map((item, i) => {
       return <ErItem key={i} />;
     });
 
-  return <StyledErsList>{renderErItems}</StyledErsList>;
+  return <div className={className}>{renderErItems}</div>;
 }
 
-const StyledErsList = styled.div`
-  height: calc(100% - 100px);
-  overflow-y: scroll;
-`;
+ErsList.propTypes = {
+  className: PropTypes.string,
+};
 
 export default ErsList;

--- a/er-allimi/src/components/ersBoxes/ErsMovingBox.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsMovingBox.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { MovingBox, ErsContent } from '@components';
+
+function ErsMovingBox({ className }) {
+  const StyledMovingErsBox = styled(MovingBox)`
+    height: calc((100vh - 70px) / 2);
+  `;
+
+  return (
+    <StyledMovingErsBox className={className}>
+      <ErsContent />
+    </StyledMovingErsBox>
+  );
+}
+
+ErsMovingBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default ErsMovingBox;

--- a/er-allimi/src/components/ersBoxes/RadiusDropdown.jsx
+++ b/er-allimi/src/components/ersBoxes/RadiusDropdown.jsx
@@ -1,8 +1,9 @@
+import PropTypes from 'prop-types';
 import { useState } from 'react';
 import styled from '@emotion/styled';
 import { Dropdown } from '@components';
 
-function RadiusDropdown() {
+function RadiusDropdown({ className }) {
   const [select, setSelect] = useState(-1);
 
   const data = [
@@ -25,8 +26,13 @@ function RadiusDropdown() {
       data={data}
       select={select}
       handleOptionClick={handleOptionClick}
+      className={className}
     />
   );
 }
+
+RadiusDropdown.propTypes = {
+  className: PropTypes.string,
+};
 
 export default RadiusDropdown;

--- a/er-allimi/src/components/ersBoxes/index.js
+++ b/er-allimi/src/components/ersBoxes/index.js
@@ -7,3 +7,5 @@ export { default as RadiusDropdown } from './RadiusDropdown';
 export { default as ErsPagination } from './ErsPagination';
 export { default as ViewToggle } from './ViewToggle';
 export { default as ViewButton } from './ViewButton';
+export { default as ErsContent } from './ErsContent';
+export { default as ErsMovingBox } from './ErsMovingBox';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -9,6 +9,8 @@ export { RadiusDropdown } from './ersBoxes';
 export { ErsPagination } from './ersBoxes';
 export { ViewToggle } from './ersBoxes';
 export { ViewButton } from './ersBoxes';
+export { ErsContent } from './ersBoxes';
+export { ErsMovingBox } from './ersBoxes';
 
 export { Box } from './ui';
 export { Input } from './ui';

--- a/er-allimi/src/components/ui/Dropdown.jsx
+++ b/er-allimi/src/components/ui/Dropdown.jsx
@@ -47,6 +47,7 @@ function Dropdown({ label, data, select, handleOptionClick, className }) {
 
 const StyledDropdown = styled.div`
   position: relative;
+  font-size: 13px;
   cursor: pointer;
 `;
 
@@ -58,7 +59,7 @@ const Head = styled.div`
   background-color: white;
   border: 1px solid ${({ theme }) => theme.colors.grayLight};
   border-radius: 0.3rem;
-  font-size: 13px;
+  font-size: inherit;
 
   svg {
     margin-left: 0.2rem;
@@ -77,12 +78,13 @@ const Body = styled.div`
   border: 1px solid ${({ theme }) => theme.colors.grayLight};
   border-top: none;
   border-radius: 0 0 0.3rem 0.3rem;
+  font-size: inherit;
 `;
 
 const Option = styled.div`
   padding: 0.2rem 0.5rem;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grayLight};
-  font-size: 13px;
+  font-size: inherit;
 
   &:hover {
     background-color: ${({ theme }) => theme.colors.grayLighter};

--- a/er-allimi/src/components/ui/MovingBox.jsx
+++ b/er-allimi/src/components/ui/MovingBox.jsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { VscTriangleDown, VscTriangleUp } from '@components';
 
-function MovingBox({ className }) {
-  const [isExpanded, setIsExpanded] = useState(false);
+function MovingBox({ className, children }) {
+  const [isExpanded, setIsExpanded] = useState(true);
 
   const handleTriangleClick = () => {
     setIsExpanded(!isExpanded);
@@ -13,10 +13,10 @@ function MovingBox({ className }) {
 
   return (
     <StyledMovingBox className={className} isExpanded={isExpanded}>
-      <div onClick={handleTriangleClick}>
+      <ExpandIcon onClick={handleTriangleClick}>
         {isExpanded ? <VscTriangleDown /> : <VscTriangleUp />}
-      </div>
-      무빙박스
+      </ExpandIcon>
+      {children}
     </StyledMovingBox>
   );
 }
@@ -30,18 +30,20 @@ const expand = ({ isExpanded }) =>
 const StyledMovingBox = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: start;
   align-items: center;
-  justify-content: space-between;
-  padding: 0 1rem 0.7rem 1rem;
+  padding: 0rem 1rem 0.7rem 1rem;
   width: 100%;
   height: 100%;
   background-color: white;
-  border-radius: 0.5rem 0.5rem 0 0;
+  border-radius: 0.7rem 0.7rem 0 0;
   box-shadow: -3px 0 5px 3px ${({ theme }) => theme.colors.grayLight};
   transition: transform 0.3s linear;
 
   ${expand}
+`;
 
+const ExpandIcon = styled.div`
   svg {
     font-size: 2rem;
     color: ${({ theme }) => theme.colors.gray};
@@ -51,6 +53,7 @@ const StyledMovingBox = styled.div`
 
 MovingBox.propTypes = {
   className: PropTypes.string,
+  children: PropTypes.node,
 };
 
 export default MovingBox;

--- a/er-allimi/src/components/ui/Pagination.jsx
+++ b/er-allimi/src/components/ui/Pagination.jsx
@@ -33,6 +33,7 @@ function Pagination({
 const StyledPagination = styled.div`
   display: flex;
   justify-content: center;
+  font-size: 13px;
 `;
 
 const activePageNum = ({ theme, active }) =>
@@ -47,12 +48,11 @@ const activePageNum = ({ theme, active }) =>
 const PageNum = styled.span`
   display: inline-block;
   margin-right: 0.5rem;
-  padding: 0.3rem 0.45rem;
+  padding: 0rem 0.35rem;
   border: 1px solid ${({ theme }) => theme.colors.gray};
   border-radius: 50%;
   color: ${({ theme }) => theme.colors.gray};
-  line-height: 13px;
-  font-size: 13px;
+  font-size: inherit;
   cursor: pointer;
 
   &:nth-last-of-type(1) {

--- a/er-allimi/src/pages/ErsBoxes.jsx
+++ b/er-allimi/src/pages/ErsBoxes.jsx
@@ -8,6 +8,7 @@ import {
   ViewToggle,
   CurrentLocationInput,
   ViewButton,
+  ErsMovingBox,
 } from '@components';
 
 function ErsBoxes({ className }) {
@@ -24,7 +25,9 @@ function ErsBoxes({ className }) {
         <StyledCurrentLocationInput />
         <StyledViewButton />
       </LayoutTop>
-      <LayoutBottom></LayoutBottom>
+      <LayoutBottom>
+        <StyledErsMovingBox />
+      </LayoutBottom>
       <Outlet />
     </StyledErsBoxes>
   );
@@ -125,6 +128,10 @@ const StyledCurrentLocationInput = styled(CurrentLocationInput)`
 `;
 
 const StyledViewButton = styled(ViewButton)`
+  ${zIndexBox}
+`;
+
+const StyledErsMovingBox = styled(ErsMovingBox)`
   ${zIndexBox}
 `;
 


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- (화면 너비 md 이상) ErsBox
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/56c8e070-5032-436c-b1a3-1b6bfb838737)

- (화면 너비 md 이하) ErsMovingBox
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/ccbb21ce-5ea6-480d-af52-fb565964fcc3)

## 작업 내용
- ErsContent 컴포넌트 생성
- ErsBox에서 내부 content 전부를 ErsContent로 이동시킴
- MovingBox에 children prop 추가 및 스타일 변경
- ErsMovingBox 컴포넌트 구현
- ErsBoxes 페이지에 ErsMovingBox 추가
- ErsList에 className prop 추가
- ErsList 내 스타일을 ErsContent로 이동시킴
- ErItem 스타일 추가 및 수정
- Pagination 스타일 수정
- Dropdown 스타일 수정
- RadiusDropdown에 className prop 추가

## 논의할 부분