### PR TITLE
[Feat] getAddressByCoor 함수 구현 & [Feat] userLocationState atom에 address 필드 추가한 후, 좌표로부터 주소 정보 가져와 저장

### DIFF
--- a/er-allimi/src/components/ersBoxes/CurrentLocationInput.jsx
+++ b/er-allimi/src/components/ersBoxes/CurrentLocationInput.jsx
@@ -1,12 +1,21 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import styled from '@emotion/styled';
 import { Input, IoLocationSharp, Button } from '@components';
+import { userLocationState } from '@stores';
 
 function CurrentLocationInput({ className }) {
+  const { address } = useRecoilValue(userLocationState);
   const [value, setValue] = useState(
-    '서울특별시 강남구 가로수길 69 (신사동, 엘큐브/elcube)',
+    address.road_address?.address_name || address.address?.address_name || '',
   );
+
+  useEffect(() => {
+    setValue(
+      address.road_address?.address_name || address.address?.address_name || '',
+    );
+  }, [address]);
 
   const handleInputChange = (e) => {
     setValue(e.target.value);

--- a/er-allimi/src/hooks/useGetUserLocation.js
+++ b/er-allimi/src/hooks/useGetUserLocation.js
@@ -1,15 +1,18 @@
 import { useSetRecoilState } from 'recoil';
 import { userLocationState } from '@stores';
+import { getAddressByCoor } from '@utils';
 
-// 사용자 위치 정보 가져오기
+// 사용자의 위치 정보를 가져와 recoil에 저장
 function useGetUserLocation() {
   const setUserLocationState = useSetRecoilState(userLocationState);
 
-  const handleGetCurPosSuccess = (position) => {
+  const handleGetCurPosSuccess = async (position) => {
     const latitude = position.coords.latitude;
     const longitude = position.coords.longitude;
-    console.log(longitude, latitude);
-    setUserLocationState({ latitude, longitude });
+
+    const address = await getAddressByCoor({ latitude, longitude });
+
+    setUserLocationState({ latitude, longitude, address });
   };
 
   const handleGetCurPosFail = (err) => {

--- a/er-allimi/src/stores/atoms/userLocationState.js
+++ b/er-allimi/src/stores/atoms/userLocationState.js
@@ -5,6 +5,7 @@ const userLocationState = atom({
   default: {
     latitude: null,
     longitude: null,
+    address: {},
   },
 });
 

--- a/er-allimi/src/utils/getAddressByCoor.js
+++ b/er-allimi/src/utils/getAddressByCoor.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+// 좌표(위도, 경도)로 주소 변환하기
+const getAddressByCoor = async ({ latitude, longitude }) => {
+  const key = import.meta.env.VITE_REST_API_KEY;
+
+  const res = await axios({
+    baseURL: 'https://dapi.kakao.com',
+    url: '/v2/local/geo/coord2address.json',
+    method: 'get',
+    headers: {
+      Authorization: `KakaoAK ${key}`,
+    },
+    params: {
+      x: longitude,
+      y: latitude,
+    },
+  });
+
+  return res.data?.documents[0];
+};
+
+export { getAddressByCoor };

--- a/er-allimi/src/utils/index.js
+++ b/er-allimi/src/utils/index.js
@@ -1,3 +1,4 @@
 export { getPathHospitalDetail } from './pathes';
 export { getDistanceFromLocation } from './getDistanceFromLocation';
 export { getErRTavailableBedByColor } from './getErRTavailableBedByColor';
+export { getAddressByCoor } from './getAddressByCoor';


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/9cb897a6-6204-4e34-953b-3bd1794cbf9b)

## 작업 내용
- 사용자의 좌표(위도, 경도)로부터 주소 정보를 반환하는 getAddressByCoor 함수 구현
-  userLocationState atom에 address 필드 추가
- useGetUserLocation hook에서 좌표로부터 주소 정보 가져와 userLocationState atom에 위도/경도와 함께 주소도 저장
- CurrentLocationInput 컴포넌트에서 userLocationState atom 내 저장된 주소 가져와서 입력창에 표시

## 논의할 부분