### PR TITLE
[Feat] useLocationState atom에서 address 필드 수정 & [Feat] getCoorByAddress 함수 구현 & [Feat] PostCodeButton 구현

### DIFF
--- a/er-allimi/index.html
+++ b/er-allimi/index.html
@@ -10,6 +10,8 @@
       type="text/javascript"
       src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%VITE_KAKAO_MAP_KEY%"
     ></script>
+    <!-- Daum Postcode -->
+    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/er-allimi/src/components/ersBoxes/CurrentLocationBox.jsx
+++ b/er-allimi/src/components/ersBoxes/CurrentLocationBox.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { Box, CurrentLocationInput, Button } from '@components';
+import { Box, CurrentLocationInput, PostCodeButton } from '@components';
 
 function CurrentLocationBox({ className }) {
   return (
@@ -12,9 +12,7 @@ function CurrentLocationBox({ className }) {
           현재 자신의 위치 정보가 일치하지 않을경우 <br />
           위치 찾기에서 주소를 검색하시면 재설정합니다.
         </Text>
-        <Button color="gray" round="lg">
-          위치 찾기
-        </Button>
+        <PostCodeButton />
       </Body>
     </Box>
   );

--- a/er-allimi/src/components/ersBoxes/CurrentLocationInput.jsx
+++ b/er-allimi/src/components/ersBoxes/CurrentLocationInput.jsx
@@ -2,19 +2,18 @@ import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from '@emotion/styled';
-import { Input, IoLocationSharp, Button } from '@components';
+import { Input, IoLocationSharp, PostCodeButton } from '@components';
 import { userLocationState } from '@stores';
 
 function CurrentLocationInput({ className }) {
   const { address } = useRecoilValue(userLocationState);
+
   const [value, setValue] = useState(
-    address.road_address?.address_name || address.address?.address_name || '',
+    address.road_address || address.address || '',
   );
 
   useEffect(() => {
-    setValue(
-      address.road_address?.address_name || address.address?.address_name || '',
-    );
+    setValue(address.road_address || address.address || '');
   }, [address]);
 
   const handleInputChange = (e) => {
@@ -44,7 +43,7 @@ function CurrentLocationInput({ className }) {
     }
   `;
 
-  const StyledButton = styled(Button)`
+  const StyledButton = styled(PostCodeButton)`
     padding: 0.1rem 0;
     width: 5rem;
   `;

--- a/er-allimi/src/components/ersBoxes/PostCodeButton.jsx
+++ b/er-allimi/src/components/ersBoxes/PostCodeButton.jsx
@@ -1,0 +1,77 @@
+import PropTypes from 'prop-types';
+import { useSetRecoilState } from 'recoil';
+import { userLocationState } from '@stores';
+import { Button } from '@components';
+import { getCoorByAddress } from '@utils';
+import { theme } from '@styles';
+
+const width =
+  document.body.offsetWidth > 768
+    ? 500
+    : document.body.offsetWidth > 320
+    ? 400
+    : 300;
+const height =
+  document.body.offsetWidth > 768
+    ? 600
+    : document.body.offsetWidth > 320
+    ? 500
+    : 400;
+
+const themeObj = {
+  bgColor: theme.colors.grayLighter, //바탕 배경색
+  pageBgColor: theme.colors.gray, //페이지 배경색
+  textColor: theme.colors.grayDarker, //기본 글자색
+  queryTextColor: theme.colors.grayDarker, //검색창 글자색
+  postcodeTextColor: theme.colors.red, //우편번호 글자색
+};
+
+function PostCodeButton({ className }) {
+  const setUserLocationState = useSetRecoilState(userLocationState);
+
+  const handleButtonClick = () => {
+    new window.daum.Postcode({
+      oncomplete: async function (data) {
+        const { roadAddress, jibunAddress } = data;
+
+        const { longitude, latitude } = await getCoorByAddress({
+          address: jibunAddress || roadAddress,
+        });
+
+        setUserLocationState({
+          latitude,
+          longitude,
+          address: {
+            address: jibunAddress,
+            road_address: roadAddress,
+          },
+        });
+      },
+      width, //생성자에 크기 값을 명시적으로 지정해야 합니다.
+      height,
+      theme: themeObj,
+    }).open({
+      left: window.screen.width / 2 - width / 2,
+      top: window.screen.height / 2 - height / 2,
+      popupTitle: '우편번호 검색 팝업', //팝업창 타이틀 설정 (영문,한글,숫자 모두 가능)
+      popupKey: 'popup1',
+    });
+  };
+
+  return (
+    <Button
+      className={className}
+      color="gray"
+      round="lg"
+      onClick={handleButtonClick}
+    >
+      위치 찾기
+    </Button>
+  );
+}
+
+PostCodeButton.propTypes = {
+  className: PropTypes.string,
+};
+
+export default PostCodeButton;

--- a/er-allimi/src/components/ersBoxes/index.js
+++ b/er-allimi/src/components/ersBoxes/index.js
@@ -9,3 +9,4 @@ export { default as ViewToggle } from './ViewToggle';
 export { default as ViewButton } from './ViewButton';
 export { default as ErsContent } from './ErsContent';
 export { default as ErsMovingBox } from './ErsMovingBox';
+export { default as PostCodeButton } from './PostCodeButton';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -11,6 +11,7 @@ export { ViewToggle } from './ersBoxes';
 export { ViewButton } from './ersBoxes';
 export { ErsContent } from './ersBoxes';
 export { ErsMovingBox } from './ersBoxes';
+export { PostCodeButton } from './ersBoxes';
 
 export { Box } from './ui';
 export { Input } from './ui';

--- a/er-allimi/src/hooks/useGetUserLocation.js
+++ b/er-allimi/src/hooks/useGetUserLocation.js
@@ -10,9 +10,17 @@ function useGetUserLocation() {
     const latitude = position.coords.latitude;
     const longitude = position.coords.longitude;
 
-    const address = await getAddressByCoor({ latitude, longitude });
+    const addressData = await getAddressByCoor({ latitude, longitude });
+    const { address, road_address } = addressData;
 
-    setUserLocationState({ latitude, longitude, address });
+    setUserLocationState({
+      latitude,
+      longitude,
+      address: {
+        address: address?.address_name,
+        road_address: road_address?.address_name,
+      },
+    });
   };
 
   const handleGetCurPosFail = (err) => {

--- a/er-allimi/src/stores/atoms/userLocationState.js
+++ b/er-allimi/src/stores/atoms/userLocationState.js
@@ -5,7 +5,10 @@ const userLocationState = atom({
   default: {
     latitude: null,
     longitude: null,
-    address: {},
+    address: {
+      address: '',
+      road_address: '',
+    },
   },
 });
 

--- a/er-allimi/src/utils/getCoorByAddress.js
+++ b/er-allimi/src/utils/getCoorByAddress.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+// 주소로 좌표(위도, 경도) 변환하기
+const getCoorByAddress = async ({ address }) => {
+  const key = import.meta.env.VITE_REST_API_KEY;
+
+  const res = await axios({
+    baseURL: 'https://dapi.kakao.com',
+    url: '/v2/local/search/address.json',
+    method: 'get',
+    headers: {
+      Authorization: `KakaoAK ${key}`,
+    },
+    params: {
+      query: address,
+    },
+  });
+
+  const { x: longitude, y: latitude } = res.data?.documents[0] || {};
+
+  return { longitude: +longitude, latitude: +latitude };
+};
+
+export { getCoorByAddress };

--- a/er-allimi/src/utils/index.js
+++ b/er-allimi/src/utils/index.js
@@ -2,3 +2,4 @@ export { getPathHospitalDetail } from './pathes';
 export { getDistanceFromLocation } from './getDistanceFromLocation';
 export { getErRTavailableBedByColor } from './getErRTavailableBedByColor';
 export { getAddressByCoor } from './getAddressByCoor';
+export { getCoorByAddress } from './getCoorByAddress';


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/68454a63-8953-485b-ab3a-5be28ed784f5)

## 작업 내용
- useLocationState atom에서 address 필드를 {}에서 {address: '', road_address: ''}로 수정
- useGetUserLocation hook에서 사용자 위치 정보에 따른 주소 정보를 가져온 후, useLocationState atom의 address 필드에 {address: '', road_address: ''} 형식으로 저장되게 수정
- 주소로부터 좌표 정보를 반환하는 getCoorByAddress 함수 구현
- daum postcode API cdn 연결 
- 클릭했을 때 우표 번호 팝업창이 뜨는 PostCodeButton 구현
- CurrentLocationInput과 CurrentLocationBox 컴포넌트에 PostCodeButton 추가

## 논의할 부분