### PR TITLE
[Fix] 마커 z-index의 최댓값보다 인포인도우 z-index가 더 크게 수정

### DIFF
--- a/er-allimi/src/pages/Map.jsx
+++ b/er-allimi/src/pages/Map.jsx
@@ -165,7 +165,7 @@ function Map() {
         content: styledInfoWindow,
         position: newMarker.getPosition(),
         yAnchor: 1,
-        zIndex: nearByErCount
+        zIndex: nearByErCount + 1
       });
 
       const markerDiv = document.querySelectorAll('.markerHover');


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/39366835/ee0b44e9-7f40-463a-b1c7-09d92b92df95)

## 작업 내용
- 마커 z-index의 최댓값보다 인포인도우 z-index가 더 크게 수정
## 논의할 부분