### PR TITLE
[Feat] ersPaginationState atom 추가 & [Fix] sortedErsWithRadiusState selector 수정 & [Feat] SortingButtons 생성 & [Feat] 각 컴포넌트에 recoil state 연결

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErsContent.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsContent.jsx
@@ -1,5 +1,10 @@
 import styled from '@emotion/styled';
-import { Button, ErsList, RadiusDropdown, ErsPagination } from '@components';
+import {
+  SortingButtons,
+  ErsList,
+  RadiusDropdown,
+  ErsPagination,
+} from '@components';
 
 function ErsContent() {
   const StyledErsContent = styled.div`
@@ -20,23 +25,6 @@ function ErsContent() {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 0.5rem;
-  `;
-
-  const SortingButtons = styled.div`
-    display: flex;
-    align-items: center;
-
-    button {
-      margin-right: 0.5rem;
-
-      @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
-        font-size: 12px;
-      }
-
-      @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
-        font-size: 11px;
-      }
-    }
   `;
 
   const StyledRadiusDropdown = styled(RadiusDropdown)`
@@ -78,14 +66,7 @@ function ErsContent() {
     <StyledErsContent>
       <Title>내 위치 주변 응급실 (15)</Title>
       <Utils>
-        <SortingButtons>
-          <Button color="gray" round="lg">
-            거리순
-          </Button>
-          <Button color="gray" round="lg" outline>
-            가용 병상 개수 순
-          </Button>
-        </SortingButtons>
+        <SortingButtons />
         <StyledRadiusDropdown />
       </Utils>
       <StyledErsList />

--- a/er-allimi/src/components/ersBoxes/ErsList.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsList.jsx
@@ -1,14 +1,36 @@
+import { useEffect, useRef } from 'react';
+import { useRecoilValue } from 'recoil';
 import PropTypes from 'prop-types';
 import { ErItem } from '@components';
+import { sortedErsWithRadiusState, ersPaginationState } from '@stores';
+import { ERS_CNT_PER_PAGE } from '@constants';
 
 function ErsList({ className }) {
-  const renderErItems = Array(15)
-    .fill(0)
-    .map((item, i) => {
-      return <ErItem key={i} />;
+  const ersList = useRef();
+  const data = useRecoilValue(sortedErsWithRadiusState);
+  const page = useRecoilValue(ersPaginationState);
+
+  useEffect(() => {
+    ersList.current.scrollTo(0, 0);
+  }, [page]);
+
+  const start = (page - 1) * ERS_CNT_PER_PAGE;
+  const end = page * ERS_CNT_PER_PAGE;
+  const dataPerPage = data.slice(start, end);
+
+  const renderErItems =
+    dataPerPage &&
+    dataPerPage.map((item, idx) => {
+      return (
+        <ErItem key={item.hpInfo.hpid} item={item} order={start + idx + 1} />
+      );
     });
 
-  return <div className={className}>{renderErItems}</div>;
+  return (
+    <div className={className} ref={ersList}>
+      {renderErItems}
+    </div>
+  );
 }
 
 ErsList.propTypes = {

--- a/er-allimi/src/components/ersBoxes/ErsPagination.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsPagination.jsx
@@ -1,9 +1,12 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import { Pagination } from '@components';
+import { sortedErsWithRadiusState, ersPaginationState } from '@stores';
+import { ERS_CNT_PER_PAGE } from '@constants';
 
 function ErsPagination({ className }) {
-  const [currentPage, setCurrentPage] = useState(1);
+  const sortedErsWithRadius = useRecoilValue(sortedErsWithRadiusState);
+  const [currentPage, setCurrentPage] = useRecoilState(ersPaginationState);
 
   const handlePageClick = (page) => {
     setCurrentPage(page);
@@ -11,8 +14,9 @@ function ErsPagination({ className }) {
 
   return (
     <Pagination
-      totCnt={15}
+      totCnt={sortedErsWithRadius.length}
       currentPage={currentPage}
+      cntPerPage={ERS_CNT_PER_PAGE}
       handlePageClick={handlePageClick}
       className={className}
     />

--- a/er-allimi/src/components/ersBoxes/PostCodeButton.jsx
+++ b/er-allimi/src/components/ersBoxes/PostCodeButton.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import { useSetRecoilState } from 'recoil';
-import { userLocationState } from '@stores';
+import {
+  userLocationState,
+  mapCenterPointState,
+  ersPaginationState,
+} from '@stores';
 import { Button } from '@components';
 import { getCoorByAddress } from '@utils';
 import { theme } from '@styles';
@@ -27,7 +31,9 @@ const themeObj = {
 };
 
 function PostCodeButton({ className }) {
-  const setUserLocationState = useSetRecoilState(userLocationState);
+  const setUserLocation = useSetRecoilState(userLocationState);
+  const setMapCenterPoint = useSetRecoilState(mapCenterPointState);
+  const setErsPagination = useSetRecoilState(ersPaginationState);
 
   const handleButtonClick = () => {
     new window.daum.Postcode({
@@ -38,7 +44,7 @@ function PostCodeButton({ className }) {
           address: jibunAddress || roadAddress,
         });
 
-        setUserLocationState({
+        setUserLocation({
           latitude,
           longitude,
           address: {
@@ -46,6 +52,13 @@ function PostCodeButton({ className }) {
             road_address: roadAddress,
           },
         });
+
+        setMapCenterPoint({
+          latitude,
+          longitude,
+        });
+
+        setErsPagination(1);
       },
       width, //생성자에 크기 값을 명시적으로 지정해야 합니다.
       height,

--- a/er-allimi/src/components/ersBoxes/RadiusDropdown.jsx
+++ b/er-allimi/src/components/ersBoxes/RadiusDropdown.jsx
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import styled from '@emotion/styled';
 import { Dropdown } from '@components';
+import { radiusState, ersPaginationState } from '@stores';
 
 function RadiusDropdown({ className }) {
-  const [select, setSelect] = useState(-1);
+  const [radius, setRadius] = useRecoilState(radiusState);
+  const setErsPagination = useSetRecoilState(ersPaginationState);
 
   const data = [
     { label: '2km', value: 2 },
@@ -13,7 +15,8 @@ function RadiusDropdown({ className }) {
   ];
 
   const handleOptionClick = (idx) => {
-    setSelect(idx);
+    setRadius(data[idx].value);
+    setErsPagination(1);
   };
 
   const StyledDropdown = styled(Dropdown)`
@@ -24,7 +27,7 @@ function RadiusDropdown({ className }) {
     <StyledDropdown
       label="반경"
       data={data}
-      select={select}
+      select={data.findIndex((item) => item.value === radius)}
       handleOptionClick={handleOptionClick}
       className={className}
     />

--- a/er-allimi/src/components/ersBoxes/SortingButtons.jsx
+++ b/er-allimi/src/components/ersBoxes/SortingButtons.jsx
@@ -1,0 +1,54 @@
+import { useRecoilState } from 'recoil';
+import styled from '@emotion/styled';
+import { Button } from '@components';
+import { sortingState } from '@stores';
+import { SORTING_DISTANCE, SORTING_AVAILABLE_BED } from '@constants';
+
+function SortingButtons() {
+  const [sorting, serSorting] = useRecoilState(sortingState);
+
+  const handleButtonClick = (sortBy) => {
+    serSorting(sortBy);
+  };
+
+  const StyledSortingButtons = styled.div`
+    display: flex;
+    align-items: center;
+
+    button {
+      margin-right: 0.5rem;
+      padding: 0.2rem 0.6rem;
+
+      @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+        font-size: 12px;
+      }
+
+      @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+        font-size: 11px;
+      }
+    }
+  `;
+
+  return (
+    <StyledSortingButtons>
+      <Button
+        color="gray"
+        round="lg"
+        outline={sorting !== SORTING_DISTANCE}
+        onClick={() => handleButtonClick(SORTING_DISTANCE)}
+      >
+        거리순
+      </Button>
+      <Button
+        color="gray"
+        round="lg"
+        outline={sorting !== SORTING_AVAILABLE_BED}
+        onClick={() => handleButtonClick(SORTING_AVAILABLE_BED)}
+      >
+        가용 병상 개수 순
+      </Button>
+    </StyledSortingButtons>
+  );
+}
+
+export default SortingButtons;

--- a/er-allimi/src/components/ersBoxes/index.js
+++ b/er-allimi/src/components/ersBoxes/index.js
@@ -10,3 +10,4 @@ export { default as ViewButton } from './ViewButton';
 export { default as ErsContent } from './ErsContent';
 export { default as ErsMovingBox } from './ErsMovingBox';
 export { default as PostCodeButton } from './PostCodeButton';
+export { default as SortingButtons } from './SortingButtons';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -12,6 +12,7 @@ export { ViewButton } from './ersBoxes';
 export { ErsContent } from './ersBoxes';
 export { ErsMovingBox } from './ersBoxes';
 export { PostCodeButton } from './ersBoxes';
+export { SortingButtons } from './ersBoxes';
 
 export { Box } from './ui';
 export { Input } from './ui';

--- a/er-allimi/src/constants/index.js
+++ b/er-allimi/src/constants/index.js
@@ -6,3 +6,4 @@ export {
   DEFAULT_ADDRESS,
   DEFAULT_ROAD_ADDRESS,
 } from './defaultLocation';
+export { ERS_CNT_PER_PAGE } from './pagination';

--- a/er-allimi/src/constants/pagination.js
+++ b/er-allimi/src/constants/pagination.js
@@ -1,0 +1,4 @@
+// MapView 페이지 내 '내 위치 주변 응급실' 박스에서 페이지당 응급실 개수
+const ERS_CNT_PER_PAGE = 10;
+
+export { ERS_CNT_PER_PAGE };

--- a/er-allimi/src/stores/atoms/ersPaginationState.js
+++ b/er-allimi/src/stores/atoms/ersPaginationState.js
@@ -1,0 +1,9 @@
+import { atom } from 'recoil';
+
+// 전체 응급실 페이지네이션
+const ersPaginationState = atom({
+  key: 'ersPaginationState',
+  default: 1,
+});
+
+export { ersPaginationState };

--- a/er-allimi/src/stores/atoms/index.js
+++ b/er-allimi/src/stores/atoms/index.js
@@ -4,3 +4,4 @@ export { sortingState } from './sortingState';
 export { mapCenterPointState } from './mapCenterPointState';
 export { ersListState } from './ersListState';
 export { ersRTavailableBedState } from './ersRTavailableBedState';
+export { ersPaginationState } from './ersPaginationState';

--- a/er-allimi/src/stores/index.js
+++ b/er-allimi/src/stores/index.js
@@ -4,6 +4,7 @@ export { sortingState } from './atoms';
 export { mapCenterPointState } from './atoms';
 export { ersListState } from './atoms';
 export { ersRTavailableBedState } from './atoms';
+export { ersPaginationState } from './atoms';
 
 export { ersWithRadiusState } from './selectors';
 export { sortedErsWithRadiusState } from './selectors';

--- a/er-allimi/src/stores/selectors/sortedErsWithRadiusState.js
+++ b/er-allimi/src/stores/selectors/sortedErsWithRadiusState.js
@@ -18,9 +18,15 @@ const sortedErsWithRadiusState = selector({
           (a, b) => a.distanceFromLocation - b.distanceFromLocation,
         );
         break;
-      case SORTING_AVAILABLE_BED: // (입원실 일반) 가용 병상 개수에 따라 내림차순 정렬
+      case SORTING_AVAILABLE_BED: // (응급실 일반) 가용 병상 개수에 따라 내림차순 정렬
         sortedErsWithRadius = [...ersWithRadius].sort((a, b) => {
-          b.availableBedInfo.hvgc - a.availableBedInfo.hvgc;
+          const aInfo = a.availableBedInfo?.hvec;
+          const bInfo = b.availableBedInfo?.hvec;
+
+          if (!aInfo) return 1; // 젤 끝에 위치
+          if (!bInfo) return -1; // 젤 끝에 위치
+
+          return bInfo - aInfo;
         });
         break;
       default:


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- MapView 페이지
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/f7637907-24ee-4e3f-ac33-fd4aba02d7d3)
- 정렬 기준 변경 시
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/01822c32-8f96-48d3-8a6a-bee82bd822c8)
- 반경 변경 시
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/d285f5ca-f2e8-4b21-aba1-aa3abb70915f)
- 페이지 변경 시
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/18081158-46c2-4698-bdf8-bfb5f85a3bfd)

## 작업 내용
- MapView 페이지에서 '내 위치 주변 응급실' 박스 내 현재 페이지 정보를 담는 ersPaginationState atom 추가
- 페이지당 응급실 개수(ERS_CNT_PER_PAGE) constant 생성
-  sortedErsWithRadiusState selector 수정
   - 입원실 일반(hvgc) -> 응급실 일반(hvec)
   - availableBedInfo 데이터가 없는 응급실의 경우, '가용 병상 개수 순'으로 정렬 시 가장 뒤에 오도록 구현
- ErsContent 컴포넌트에서 정렬 버튼들을 떼어내 따로 SortingButtons 컴포넌트로 생성
- SortingButtons 컴포넌트에서 정렬 기준 변경 시, sortingState 값 변경
- RadiusDropdown 컴포넌트에서 반경 변경 시, radiusState 값을 변경하고 ersPaginationState 값은 1로 초기화
- ErsPagination 컴포넌트에 페이지 변경 시, ersPaginationState 값 변경
- PostCodeButton 컴포넌트에서 complete 시, mapCenterPointState 값을 해당 좌표로 변경하고 ersPaginationState 값은 1로 초기화
- ErsList 컴포넌트에서 sortedErsWithRadiusState 데이터 연결 및 현재 페이지 별로 데이터를 끊어서 보여줌
- ErItem 컴포넌트에 데이터 연결

## 논의할 부분
- '내 위치 주변 응급실(15)' 제목 안에 있는 응급실 총 개수는 차후 변경해서 푸시할 예정