### PR TITLE
[Feat] hpDetailPage layout 구현

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpInfoBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpInfoBox.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import { Box } from '@components';
+
+function HpInfoBox({ className }) {
+  return <Box className={className}>병원 기본정보</Box>;
+}
+
+HpInfoBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default HpInfoBox;

--- a/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import { Box } from '@components';
+
+function HpMessageBox({ className }) {
+  return <Box className={className}>응급실 메시지</Box>;
+}
+
+HpMessageBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default HpMessageBox;

--- a/er-allimi/src/components/hpDetailBoxes/HpMovingBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMovingBox.jsx
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { MovingBox } from '@components';
+
+function HpMovingBox({ className }) {
+  return (
+    <StyledMovingErsBox className={className}>
+      하단 디테일 박스
+    </StyledMovingErsBox>
+  );
+}
+const StyledMovingErsBox = styled(MovingBox)`
+    height: calc((100vh - 70px) / 2);
+  `;
+  
+HpMovingBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default HpMovingBox;

--- a/er-allimi/src/components/hpDetailBoxes/HpRtErAvailableBedBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpRtErAvailableBedBox.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import { ClosedBox, AiTwotoneAlert } from '@components';
+
+function HpRtErAvailableBedBox({ className }) {
+  return (
+    <ClosedBox className={className} icon={<AiTwotoneAlert />}>
+      실시간 응급실 가용 병상 정보
+    </ClosedBox>
+  );
+}
+
+HpRtErAvailableBedBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default HpRtErAvailableBedBox;

--- a/er-allimi/src/components/hpDetailBoxes/HpRtHrAvailableBedBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpRtHrAvailableBedBox.jsx
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import { ClosedBox, FaBed } from '@components';
+
+function HpRtHrAvailableBedBox({ className }) {
+  return <ClosedBox className={className} icon={<FaBed />}>실시간 입원실 가용 병상 정보</ClosedBox>;
+}
+
+HpRtHrAvailableBedBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default HpRtHrAvailableBedBox;

--- a/er-allimi/src/components/hpDetailBoxes/HpSrIIIBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpSrIIIBox.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types';
+import { ClosedBox, BiBody } from '@components';
+
+function HpSrIIIBox({ className }) {
+  return (
+    <ClosedBox className={className} icon={<BiBody />}>
+      중증질환정보
+    </ClosedBox>
+  );
+}
+
+HpSrIIIBox.propTypes = {
+  className: PropTypes.string,
+};
+
+export default HpSrIIIBox;

--- a/er-allimi/src/components/hpDetailBoxes/index.js
+++ b/er-allimi/src/components/hpDetailBoxes/index.js
@@ -1,0 +1,8 @@
+export { default as HpMessageList } from './HpMessageList';
+export { default as HpMessageItem } from './HpMessageItem';
+export { default as HpMovingBox } from './HpMovingBox';
+export { default as HpInfoBox } from './HpInfoBox';
+export { default as HpMessageBox } from './HpMessageBox';
+export { default as HpRtErAvailableBedBox } from './HpRtErAvailableBedBox';
+export { default as HpRtHrAvailableBedBox } from './HpRtHrAvailableBedBox';
+export { default as HpSrIIIBox } from './HpSrIIIBox';

--- a/er-allimi/src/components/icons/index.js
+++ b/er-allimi/src/components/icons/index.js
@@ -1,16 +1,16 @@
-export { BiCurrentLocation } from 'react-icons/bi';
+export {
+  BiCurrentLocation,
+  BiSolidPhone,
+  BiSolidDownArrow,
+  BiSolidUpArrow,
+  BiBody,
+} from 'react-icons/bi';
 export { GrMapLocation } from 'react-icons/gr';
-export { FaMapMarkedAlt } from 'react-icons/fa';
-export { AiOutlineInfoCircle } from 'react-icons/ai';
+export { FaMapMarkedAlt, FaMapMarker, FaBed } from 'react-icons/fa';
+export { AiOutlineInfoCircle, AiTwotoneAlert,  } from 'react-icons/ai';
 export { RxHamburgerMenu } from 'react-icons/rx';
-export { AiOutlinePlus } from 'react-icons/ai';
-export { AiOutlineMinus } from 'react-icons/ai';
-export { IoLocationSharp } from 'react-icons/io5';
-export { FaMapMarker } from 'react-icons/fa';
-export { BiSolidPhone } from 'react-icons/bi';
-export { BiSolidDownArrow } from 'react-icons/bi';
-export { BiSolidUpArrow } from 'react-icons/bi';
+export { AiOutlinePlus, AiOutlineMinus } from 'react-icons/ai';
+export { IoLocationSharp, IoCloseSharp } from 'react-icons/io5';
 export { MdOutlineInsertChartOutlined } from 'react-icons/md';
-export { VscTriangleDown } from 'react-icons/vsc';
-export { VscTriangleUp } from 'react-icons/vsc';
+export { VscTriangleDown, VscTriangleUp } from 'react-icons/vsc';
 export { BsFillCircleFill } from 'react-icons/bs';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -1,54 +1,64 @@
 export { Navbar } from './app';
 
-export { CurrentLocationInput } from './ersBoxes';
-export { CurrentLocationBox } from './ersBoxes';
-export { ErsBox } from './ersBoxes';
-export { ErsList } from './ersBoxes';
-export { ErItem } from './ersBoxes';
-export { RadiusDropdown } from './ersBoxes';
-export { ErsPagination } from './ersBoxes';
-export { ViewToggle } from './ersBoxes';
-export { ViewButton } from './ersBoxes';
-export { ErsContent } from './ersBoxes';
-export { ErsMovingBox } from './ersBoxes';
-export { PostCodeButton } from './ersBoxes';
+export {
+  CurrentLocationInput,
+  CurrentLocationBox,
+  ErsBox,
+  ErsList,
+  ErItem,
+  RadiusDropdown,
+  ErsPagination,
+  ViewToggle,
+  ViewButton,
+  ErsContent,
+  ErsMovingBox,
+  PostCodeButton
+} from './ersBoxes';
 
-export { Box } from './ui';
-export { Input } from './ui';
-export { Button } from './ui';
-export { Dropdown } from './ui';
-export { Pagination } from './ui';
-export { Toggle } from './ui';
-export { MovingBox } from './ui';
-export { ClosedBox } from './ui';
+export {
+  Box,
+  Input,
+  Button,
+  Dropdown,
+  Pagination,
+  Toggle,
+  MovingBox,
+  ClosedBox
+} from './ui';
 
-export { BiCurrentLocation } from './icons';
-export { GrMapLocation } from './icons';
-export { FaMapMarkedAlt } from './icons';
-export { AiOutlineInfoCircle } from './icons';
-export { RxHamburgerMenu } from './icons';
-export { AiOutlinePlus } from './icons';
-export { AiOutlineMinus } from './icons';
-export { IoLocationSharp } from './icons';
-export { FaMapMarker } from './icons';
-export { BiSolidPhone } from './icons';
-export { BiSolidDownArrow } from './icons';
-export { BiSolidUpArrow } from './icons';
-export { MdOutlineInsertChartOutlined } from './icons';
-export { VscTriangleDown } from './icons';
-export { VscTriangleUp } from './icons';
-export { BsFillCircleFill } from './icons';
-export { AiTwotoneAlert } from './icons';
-export { IoCloseSharp } from './icons';
-export { FaBed } from './icons';
-export { BiBody } from './icons';
+export {
+  BiCurrentLocation,
+  GrMapLocation,
+  FaMapMarkedAlt,
+  AiOutlineInfoCircle,
+  RxHamburgerMenu,
+  AiOutlinePlus,
+  AiOutlineMinus,
+  IoLocationSharp,
+  FaMapMarker,
+  BiSolidPhone,
+  BiSolidDownArrow,
+  BiSolidUpArrow,
+  MdOutlineInsertChartOutlined,
+  VscTriangleDown,
+  VscTriangleUp,
+  BsFillCircleFill,
+  AiTwotoneAlert,
+  IoCloseSharp,
+  FaBed,
+  BiBody
+} from './icons';
 
-export { CurrentLocationButton } from './map';
-export { ZoomInButton } from './map';
-export { ZoomOutButton } from './map';
-export { CurrentLocationOverlay } from './map';
-export { ErMarkerOverlay } from './map';
-export { InfoWindowOverlay } from './map';
+
+export {
+  CurrentLocationButton,
+  ZoomInButton,
+  ZoomOutButton,
+  CurrentLocationOverlay,
+  ErMarkerOverlay,
+  InfoWindowOverlay
+} from './map';
+
 
 export {
   HpMessageItem,

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -20,6 +20,7 @@ export { Dropdown } from './ui';
 export { Pagination } from './ui';
 export { Toggle } from './ui';
 export { MovingBox } from './ui';
+export { ClosedBox } from './ui';
 
 export { BiCurrentLocation } from './icons';
 export { GrMapLocation } from './icons';
@@ -37,6 +38,10 @@ export { MdOutlineInsertChartOutlined } from './icons';
 export { VscTriangleDown } from './icons';
 export { VscTriangleUp } from './icons';
 export { BsFillCircleFill } from './icons';
+export { AiTwotoneAlert } from './icons';
+export { IoCloseSharp } from './icons';
+export { FaBed } from './icons';
+export { BiBody } from './icons';
 
 export { CurrentLocationButton } from './map';
 export { ZoomInButton } from './map';
@@ -44,3 +49,14 @@ export { ZoomOutButton } from './map';
 export { CurrentLocationOverlay } from './map';
 export { ErMarkerOverlay } from './map';
 export { InfoWindowOverlay } from './map';
+
+export {
+  HpMessageItem,
+  HpMessageList,
+  HpMovingBox,
+  HpInfoBox,
+  HpMessageBox,
+  HpRtErAvailableBedBox,
+  HpRtHrAvailableBedBox,
+  HpSrIIIBox,
+} from './hpDetailBoxes';

--- a/er-allimi/src/components/ui/ClosedBox.jsx
+++ b/er-allimi/src/components/ui/ClosedBox.jsx
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import { Box, IoCloseSharp } from '@components';
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+function ClosedBox({ className, children, icon }) {
+  const [isClosed, setIsClosed] = useState(false);
+
+  const handleToggleClick = () => {
+    setIsClosed((prevIsClosed) => !prevIsClosed);
+  };
+  return (
+    <>
+      {isClosed ? (
+        <CircleBox className={className} onClick={handleToggleClick}>
+          {icon}
+        </CircleBox>
+      ) : (
+        <StyledBox className={className}>
+          <ClosedButtonContainer>
+            <IoCloseSharp onClick={handleToggleClick} />
+          </ClosedButtonContainer>
+          {children}
+        </StyledBox>
+      )}
+    </>
+  );
+}
+
+const StyledBox = styled(Box)`
+  position: relative;
+`;
+
+const CircleBox = styled.div`
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  color: ${({ theme }) => theme.colors.grayDarker};
+  border: 1.5px solid ${({ theme }) => theme.colors.redLighter};
+  box-shadow: 3px 3px 5px 3px ${({ theme }) => theme.colors.grayLight};
+  background-color: white;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const ClosedButtonContainer = styled.div`
+  position: absolute;
+  top: 0.25rem;
+  right: 0.55rem;
+  color: ${({ theme }) => theme.colors.gray};
+  cursor: pointer;
+`;
+ClosedBox.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+  icon: PropTypes.element,
+};
+
+export default ClosedBox;

--- a/er-allimi/src/components/ui/index.js
+++ b/er-allimi/src/components/ui/index.js
@@ -5,3 +5,4 @@ export { default as Dropdown } from './Dropdown';
 export { default as Pagination } from './Pagination';
 export { default as Toggle } from './Toggle';
 export { default as MovingBox } from './MovingBox';
+export { default as ClosedBox } from './ClosedBox';

--- a/er-allimi/src/pages/HpDetailBoxes.jsx
+++ b/er-allimi/src/pages/HpDetailBoxes.jsx
@@ -1,7 +1,174 @@
-function HpDetailBoxes() {
-    return (
-        <div>HpDetailBoxes</div>
-    );
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/react';
+import {
+  CurrentLocationBox,
+  CurrentLocationInput,
+  HpMovingBox,
+  HpInfoBox,
+  HpMessageBox,
+  HpRtErAvailableBedBox,
+  HpRtHrAvailableBedBox,
+  HpSrIIIBox,
+} from '@components';
+HpDetailBoxes.propTypes = {
+  className: PropTypes.string,
+};
+
+function HpDetailBoxes({ className }) {
+  return (
+    <Container className={className}>
+      <LayoutTop>
+        <StyledCurrentLocationInput />
+      </LayoutTop>
+      <LayoutLeft>
+        <StyledCurrentLocationBox />
+        <StyledHpInfoBox />
+        <StyledHpRtErAvailableBedBox />
+        <StyledHpRtHrAvailableBedBox />
+      </LayoutLeft>
+      <LayoutRight>
+        <StyledHpMessageBox />
+        <StyledHpSrIIIBox />
+      </LayoutRight>
+      <LayoutBottom>
+        <StyledHpMessageBox />
+        <StyledErsMovingBox />
+      </LayoutBottom>
+    </Container>
+  );
 }
 
+const Container = styled.div`
+  display: grid;
+  grid-template-rows: 1fr;
+  grid-template-columns: 300px 1fr 300px;
+  padding: 1rem;
+  width: 100%;
+  height: 100%;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      grid-template-rows: 1fr 1fr;
+      grid-template-columns: 1fr;
+      padding: 0;
+    }
+  `}
+`;
+
+const LayoutLeft = styled.div`
+  grid-row: 1/2;
+  grid-column: 1/2;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      display: none;
+    }
+  `}
+`;
+
+const LayoutRight = styled.div`
+  grid-row: 1/2;
+  grid-column: 3/4;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: end;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      display: none;
+    }
+  `}
+`;
+
+const LayoutTop = styled.div`
+  grid-row: 1/2;
+  grid-column: 1/2;
+  display: none;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+      padding: 1rem;
+    }
+  `}
+`;
+
+const LayoutBottom = styled.div`
+  grid-row: 2/3;
+  grid-column: 1/2;
+  display: none;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      grid-row: 1/3;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      align-items: end;
+    }
+  `}
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.sm}) {
+      grid-row: 2/3;
+      grid-column: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
+  `}
+`;
+
+const zIndexBox = css`
+  z-index: 1;
+`;
+
+const StyledCurrentLocationInput = styled(CurrentLocationInput)`
+  ${zIndexBox}
+`;
+
+const StyledCurrentLocationBox = styled(CurrentLocationBox)`
+  margin-bottom: 1rem;
+  ${zIndexBox}
+`;
+
+const StyledHpInfoBox = styled(HpInfoBox)`
+  margin-bottom: 1rem;
+  ${zIndexBox}
+`;
+const StyledHpRtErAvailableBedBox = styled(HpRtErAvailableBedBox)`
+  margin-bottom: 1rem;
+  ${zIndexBox}
+`;
+const StyledHpRtHrAvailableBedBox = styled(HpRtHrAvailableBedBox)`
+  ${zIndexBox}
+`;
+const StyledHpSrIIIBox = styled(HpSrIIIBox)`
+  ${zIndexBox}
+`;
+const StyledHpMessageBox = styled(HpMessageBox)`
+  ${zIndexBox}
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      margin: 1rem;
+      margin-top: 3.5rem;
+    }
+  `}
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.sm}) {
+      display: none;
+    }
+  `}
+`;
+
+const StyledErsMovingBox = styled(HpMovingBox)`
+  ${zIndexBox}
+`;
 export default HpDetailBoxes;

--- a/er-allimi/src/pages/HpDetailPage.jsx
+++ b/er-allimi/src/pages/HpDetailPage.jsx
@@ -1,12 +1,24 @@
 import { Map, HpDetailBoxes } from '@pages';
+import styled from '@emotion/styled';
 
 function HpDetailPage() {
-    return (
-        <div>
-            <Map />
-            <HpDetailBoxes />
-        </div>
-    );
+  const StyledMapView = styled.div`
+    position: relative;
+    width: 100%;
+    height: 100%;
+  `;
+
+  const AbsoluteErsBoxes = styled(HpDetailBoxes)`
+    position: absolute;
+    top: 0;
+    left: 0;
+  `;
+  return (
+    <StyledMapView>
+      <Map />
+      <AbsoluteErsBoxes />
+    </StyledMapView>
+  );
 }
 
 export default HpDetailPage;


### PR DESCRIPTION
## 사진 (구현 캡쳐)
<img src="https://github.com/ER-allimi/ER-allimi/assets/39366835/98e36a0a-f9ab-4cd3-bad3-84938811b2bb"  width="400" height="400"/>
<img src="https://github.com/ER-allimi/ER-allimi/assets/39366835/bc7f47b2-156f-47e2-8476-3bacc17af73d"  width="400" height="400"/>
<img src="https://github.com/ER-allimi/ER-allimi/assets/39366835/ad894661-3727-4d4b-ae6e-666f7c054878"  width="400" height="400"/>
<img src="https://github.com/ER-allimi/ER-allimi/assets/39366835/5383e413-ca14-4540-b4f0-f5dfda3762ad"  width="400" height="400"/>
<img src="https://github.com/ER-allimi/ER-allimi/assets/39366835/4f24bcaa-882c-43f6-9de2-655087aaf636"  width="400" height="400"/>

## 작업 내용
- 병원 디테일 페이지 기본 레이아웃 구현
- 기본 정보 박스를 제외한 실시간 응급실 가용 병상 박스, 실시간 입원실 가용 병상 박스, 중증 질환 정보 박스는 여닫기가 가능한 박스 ui로 구현
- HpDetailPage 레이아웃 구현
- HpDetailBoxes 레이아웃 구현

## 논의할 부분