### PR TITLE
[Feat] ersList 페이지네이션 목록과 맵 마커 동기화

### DIFF
--- a/er-allimi/src/constants/index.js
+++ b/er-allimi/src/constants/index.js
@@ -7,3 +7,4 @@ export {
   DEFAULT_ROAD_ADDRESS,
 } from './defaultLocation';
 export { ERS_CNT_PER_PAGE } from './pagination';
+export { KM_TO_M_UNIT } from './kmToMUnit';

--- a/er-allimi/src/constants/kmToMUnit.js
+++ b/er-allimi/src/constants/kmToMUnit.js
@@ -1,0 +1,4 @@
+// km단위 -> m단위
+const KM_TO_M_UNIT = 1000;
+
+export {KM_TO_M_UNIT}

--- a/er-allimi/src/pages/Map.jsx
+++ b/er-allimi/src/pages/Map.jsx
@@ -11,13 +11,13 @@ import {
 
 import { getErRTavailableBedByColor } from '@utils';
 import { renderToString } from 'react-dom/server';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import {
   userLocationState,
   mapCenterPointState,
   sortedErsWithRadiusState,
   radiusState,
-  ersPaginationState
+  ersPaginationState,
 } from '@stores';
 import { KM_TO_M_UNIT, ERS_CNT_PER_PAGE } from '@constants';
 
@@ -38,6 +38,7 @@ function Map() {
   const [circleOverlay, setCircleOverlay] = useState(null);
   const [erMarkers, setErMarkers] = useState([]);
   const ersPagination = useRecoilValue(ersPaginationState);
+  const resetPagination = useResetRecoilState(ersPaginationState);
 
   /** 카카오 지도 생성 */
   const createMap = () => {
@@ -131,11 +132,12 @@ function Map() {
     setErMarkers(newErMarkers);
   };
 
-  /** 중심 위치 변경 시 위도, 경도 받아옴 */
+  /** 중심 위치 변경 시 중심 위도, 경도 업데이트 및 페이지네이션 초기화 */
   const handleCenterChange = () => {
     const latLngPoint = map.getCenter();
     setCenterPosition(latLngPoint);
     setCenterPoint({ latitude: latLngPoint.Ma, longitude: latLngPoint.La });
+    resetPagination();
   };
 
   // 첫 렌더링 시 지도 생성

--- a/er-allimi/src/pages/Map.jsx
+++ b/er-allimi/src/pages/Map.jsx
@@ -140,38 +140,36 @@ function Map() {
     resetPagination();
   };
 
+  // 반경 오버레이
+  const newCircleOverlay = new kakao.maps.Circle({
+    radius: radius * KM_TO_M_UNIT,
+    center: centerPosition,
+    strokeWeight: 1,
+    strokeColor: '#a3a3a3',
+    strokeOpacity: 0.27,
+    strokeStyle: 'solid',
+    fillColor: '#a3a3a3',
+    fillOpacity: 0.2,
+  });
+
   // 첫 렌더링 시 지도 생성
   useEffect(() => {
     createMap();
   }, [latitude, longitude]);
 
-  // 중심 위치 변경 시 응급실 마커, 반경 오버레이 생성
-  useEffect(() => {
-    if (map) {
-      kakao.maps.event.addListener(map, 'center_changed', handleCenterChange);
-      createNearByErMarker();
+// 중심 위치 변경 시 응급실 마커, 반경 오버레이 생성
+useEffect(() => {
+  if (!map) return;
+  kakao.maps.event.addListener(map, 'center_changed', handleCenterChange);
+  createNearByErMarker();
 
-      // 기존 circle 오버레이 제거
-      if (circleOverlay) {
-        circleOverlay.setMap(null);
-      }
+  // 기존 circle 오버레이 제거
+  circleOverlay && circleOverlay.setMap(null);
 
-      // 새로운 circle 오버레이 생성 및 추가
-      const newCircleOverlay = new kakao.maps.Circle({
-        map,
-        radius: radius * KM_TO_M_UNIT,
-        center: centerPosition,
-        strokeWeight: 1,
-        strokeColor: '#a3a3a3',
-        strokeOpacity: 0.27,
-        strokeStyle: 'solid',
-        fillColor: '#a3a3a3',
-        fillOpacity: 0.2,
-      });
+  newCircleOverlay.setMap(map);
 
-      setCircleOverlay(newCircleOverlay);
-    }
-  }, [map, centerPosition, radius, ersPagination]);
+  setCircleOverlay(newCircleOverlay);
+}, [map, centerPosition, radius, ersPagination]);
 
   return (
     <MapContainer ref={mapContainer}>


### PR DESCRIPTION
## 사진 (구현 캡쳐)
<img src="https://github.com/ER-allimi/ER-allimi/assets/39366835/5e8e3e24-86cd-4eb8-afa0-a514b4887bcd"  width="400" height="400"/>

## 작업 내용
- ersList의 페이지네이션으로 나눈 목록과 맵 마커의 목록 동기화(10개 단위)
- 중심 위치 변경 시 페이지네이션 recoil 초기화 시킴

## 논의할 부분