### PR TITLE
[Feat] 응급실 및 중증질환 메시지 조회 useQuery 구현

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpMessageList.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageList.jsx
@@ -1,0 +1,27 @@
+import HpMessageItem from './HpMessageItem';
+
+function HpMessageList() {
+  const dummyData = [
+    {
+      type: '응급',
+      content: '소아 중증환자, 소아외상 진료함',
+      date: '2023-08-07 10:00:00',
+    },
+    {
+      type: '중증',
+      content:
+        '영상의학과 staff학회참석으로 angiography  (PCD, PTBD, pigtail,  AV shunt 관련시술) 불가',
+      date: '2023-08-07 10:00:00',
+    },
+  ];
+  return dummyData.map((data, idx) => {
+    <HpMessageItem
+      key={idx}
+      megType={data.type}
+      msgContent={data.content}
+      msgDate={data.date}
+    ></HpMessageItem>;
+  });
+}
+
+export default HpMessageList;

--- a/er-allimi/src/hooks/index.js
+++ b/er-allimi/src/hooks/index.js
@@ -1,3 +1,4 @@
 export { default as useGetUserLocation } from './useGetUserLocation';
 export { default as useFetchErList } from './useFetchErList';
 export { default as useFetchErsRTavailableBed } from './useFetchErsRTavailableBed';
+export { default as useFetchHpMsg } from './useFetchHpMsg';

--- a/er-allimi/src/hooks/useFetchHpMsg.js
+++ b/er-allimi/src/hooks/useFetchHpMsg.js
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { getErMsg } from '@services';
+function useFetchHpMsg(hpId) {
+  const query = useQuery({
+    queryKey: ['erMsg', hpId],
+    queryFn: () => getErMsg({ HPID : hpId }),
+    onError: () => {
+      alert(
+        `응급실 및 진료불가능 메시지 데이터를 가져오는데 실패했습니다.\n확인 버튼 클릭 시, 자동으로 새로고침됩니다.`,
+      );
+      location.reload();
+    },
+    retry: 3,
+    refetchInterval: 30 * 60 * 1000, // ms
+    refetchIntervalInBackground: true,
+    select: (data) => {
+      return {
+        hpId : data.hpid,
+        msgDate: data.symBlkSttDtm,
+        msgType: data.symBlkMsgTyp,
+        msgContent: data.symBlkMsg,
+        msgSymType: data.symTypCodMag,
+      };
+    },
+  });
+  return query;
+}
+
+export default useFetchHpMsg;

--- a/er-allimi/src/services/getErMsg.js
+++ b/er-allimi/src/services/getErMsg.js
@@ -11,7 +11,7 @@ const getErMsg = async ({ HPID }) => {
         HPID,
       },
     });
-    return response.data.response.body.items?.item;
+    return response.data.response.body.items?.item || '1';
   } catch (error) {
     console.error(error);
   }


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/39366835/ea472fe6-7769-4f7c-bb32-cfa425a29f8f)

## 작업 내용
- HpMessageBox에서 현재 주소 위치의 파라미터(병원id)를 가져와 응급실 및 중증질환 메시지 데이터 커스텀 훅을 호출함.

## 논의할 부분
- useQuery 사용 시 onError API는 다음 버전에서 없어질 예정.
- 에러 처리를 전역에서 관리할 필요가 있음.
- 참고 자료 https://tkdodo.eu/blog/breaking-react-querys-api-on-purpose