### PR TITLE
[Chore] 'react-hot-toast' 패키지 설치 & [Feat] RefreshButton, ErrorMessage 컴포넌트 구현 [Feat] 데이터 fetching 과정에서 에러 발생 시 토스트 띄움

### DIFF
--- a/er-allimi/package.json
+++ b/er-allimi/package.json
@@ -20,6 +20,7 @@
     "prop-type": "^0.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^4.10.1",
     "react-router-dom": "^6.15.0",
     "recoil": "^0.7.7"

--- a/er-allimi/src/App.jsx
+++ b/er-allimi/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
+import { Toaster } from 'react-hot-toast';
 import styled from '@emotion/styled';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { theme, globalStyles } from '@styles';
@@ -57,6 +58,7 @@ function App() {
           <Outlet />
         </StyledOutlet>
       </StyledApp>
+      <Toaster position="top-center" reverseOrder={false} />
     </ThemeProvider>
   );
 }

--- a/er-allimi/src/components/ersBoxes/ErrorMessage.jsx
+++ b/er-allimi/src/components/ersBoxes/ErrorMessage.jsx
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { BiSolidError, RefreshButton } from '@components';
+
+function ErrorMessage({ content, icon, iconColor, refreshButton }) {
+  return (
+    <StyledErrorMessage iconColor={iconColor}>
+      {icon}
+      <p>{content}</p>
+      {refreshButton && <RefreshButton />}
+    </StyledErrorMessage>
+  );
+}
+
+const StyledErrorMessage = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: ${({ theme }) => theme.colors.grayDark};
+
+  svg {
+    margin-right: 0.5rem;
+    font-size: 1.2rem;
+    color: ${({ theme, iconColor }) => theme.colors[iconColor]};
+  }
+
+  p {
+    margin-right: 0.5rem;
+    font-size: inherit;
+  }
+
+  button {
+    font-size: 12px;
+  }
+`;
+
+ErrorMessage.propTypes = {
+  content: PropTypes.string,
+  icon: PropTypes.element,
+  iconColor: PropTypes.oneOf([
+    'gray',
+    'grayDark',
+    'grayDarker',
+    'grayLight',
+    'grayLighter',
+    'red',
+    'redDark',
+    'redDarker',
+    'redLight',
+    'redLighter',
+    'yellow',
+    'yellowDark',
+    'yellowDarker',
+    'yellowLight',
+    'yellowLighter',
+    'green',
+    'greenDark',
+    'greenDarker',
+    'greenLight',
+    'greenLighter',
+  ]),
+  refreshButton: PropTypes.bool,
+};
+
+ErrorMessage.defaultProps = {
+  content: '에러 메시지를 입력해주세요.',
+  icon: <BiSolidError />,
+  iconColor: 'redLight',
+  refreshButton: false,
+};
+
+export default ErrorMessage;

--- a/er-allimi/src/components/ersBoxes/RefreshButton.jsx
+++ b/er-allimi/src/components/ersBoxes/RefreshButton.jsx
@@ -1,0 +1,11 @@
+import { Button } from '@components';
+
+function RefreshButton() {
+  return (
+    <Button color="gray" round="sm" onClick={() => location.reload()}>
+      새로고침
+    </Button>
+  );
+}
+
+export default RefreshButton;

--- a/er-allimi/src/components/ersBoxes/index.js
+++ b/er-allimi/src/components/ersBoxes/index.js
@@ -12,3 +12,5 @@ export { default as ErsMovingBox } from './ErsMovingBox';
 export { default as PostCodeButton } from './PostCodeButton';
 export { default as SortingButtons } from './SortingButtons';
 export { default as EmptyBox } from './EmptyBox';
+export { default as RefreshButton } from './RefreshButton';
+export { default as ErrorMessage } from './ErrorMessage';

--- a/er-allimi/src/components/icons/index.js
+++ b/er-allimi/src/components/icons/index.js
@@ -4,6 +4,7 @@ export {
   BiSolidDownArrow,
   BiSolidUpArrow,
   BiBody,
+  BiSolidError,
 } from 'react-icons/bi';
 export { GrMapLocation } from 'react-icons/gr';
 export { FaMapMarkedAlt, FaMapMarker, FaBed } from 'react-icons/fa';
@@ -11,7 +12,7 @@ export { AiOutlineInfoCircle, AiTwotoneAlert } from 'react-icons/ai';
 export { RxHamburgerMenu } from 'react-icons/rx';
 export { AiOutlinePlus, AiOutlineMinus } from 'react-icons/ai';
 export { IoLocationSharp, IoCloseSharp } from 'react-icons/io5';
-export { MdOutlineInsertChartOutlined } from 'react-icons/md';
+export { MdOutlineInsertChartOutlined, MdLocationOff } from 'react-icons/md';
 export { VscTriangleDown, VscTriangleUp } from 'react-icons/vsc';
 export { BsFillCircleFill } from 'react-icons/bs';
 export { PiArrowBendUpLeftBold } from 'react-icons/pi';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -15,6 +15,8 @@ export {
   PostCodeButton,
   SortingButtons,
   EmptyBox,
+  RefreshButton,
+  ErrorMessage,
 } from './ersBoxes';
 
 export {
@@ -52,6 +54,8 @@ export {
   PiArrowBendUpLeftBold,
   TbNoteOff,
   TbHomeOff,
+  BiSolidError,
+  MdLocationOff,
 } from './icons';
 
 export {

--- a/er-allimi/src/hooks/useFetchErList.jsx
+++ b/er-allimi/src/hooks/useFetchErList.jsx
@@ -2,6 +2,7 @@ import { useSetRecoilState } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import { getErList } from '@services';
 import { ersListState } from '@stores';
+import { ErrorMessage } from '@components';
 
 // 응급실 전체 목록 정보 가져오기
 function useFetchErList() {
@@ -11,14 +12,16 @@ function useFetchErList() {
     queryKey: ['erList'],
     queryFn: getErList,
     retry: 3,
-    onError: (err) => {
-      alert(
-        `응급실 목록 데이터를 가져오는데 실패했습니다.\n확인 버튼 클릭 시, 자동으로 새로고침됩니다.`,
-      );
-      location.reload();
-    },
     onSuccess: (data) => {
       setErsListState(data);
+    },
+    meta: {
+      errorMessage: (
+        <ErrorMessage
+          content="[실패] 응급실 목록 데이터 가져오기"
+          refreshButton
+        />
+      ),
     },
   });
 

--- a/er-allimi/src/hooks/useFetchErsRTavailableBed.jsx
+++ b/er-allimi/src/hooks/useFetchErsRTavailableBed.jsx
@@ -2,6 +2,7 @@ import { useSetRecoilState } from 'recoil';
 import { useQuery } from '@tanstack/react-query';
 import { getErRTavailableBed } from '@services';
 import { ersRTavailableBedState } from '@stores';
+import { ErrorMessage } from '@components';
 
 function useFetchErsRTavailableBed() {
   const setErsRTavailableBed = useSetRecoilState(ersRTavailableBedState);
@@ -10,14 +11,16 @@ function useFetchErsRTavailableBed() {
     queryKey: ['ersRTavailableBed'],
     queryFn: () => getErRTavailableBed({ STAGE1: '', STAGE2: '' }),
     retry: 3,
-    onError: (err) => {
-      alert(
-        `응급실 실시간 가용 병상 데이터를 가져오는데 실패했습니다.\n확인 버튼 클릭 시, 자동으로 새로고침됩니다.`,
-      );
-      location.reload();
-    },
     onSuccess: (data) => {
       setErsRTavailableBed(data);
+    },
+    meta: {
+      errorMessage: (
+        <ErrorMessage
+          content="[실패] 가용 병상 데이터 가져오기"
+          refreshButton
+        />
+      ),
     },
     refetchInterval: 30 * 60 * 1000, // ms
     refetchIntervalInBackground: true,

--- a/er-allimi/src/hooks/useGetUserLocation.jsx
+++ b/er-allimi/src/hooks/useGetUserLocation.jsx
@@ -1,6 +1,8 @@
 import { useSetRecoilState } from 'recoil';
+import toast from 'react-hot-toast';
 import { userLocationState, mapCenterPointState } from '@stores';
 import { getAddressByCoor } from '@utils';
+import { ErrorMessage, MdLocationOff } from '@components';
 
 // 사용자의 위치 정보를 가져와 recoil에 저장
 function useGetUserLocation() {
@@ -30,9 +32,13 @@ function useGetUserLocation() {
   };
 
   const handleGetCurPosFail = (err) => {
-    alert(
-      `사용자의 위치 정보를 가져오지 못했습니다.\n'응급실알리미'에서 위치 정보를 가져올 수 있게, \n설정에서 위치 접근을 허용해주세요.`,
-    );
+    toast(() => (
+      <ErrorMessage
+        content="[실패] 사용자의 위치 정보 가져오기"
+        icon={<MdLocationOff />}
+        iconColor="yellowDark"
+      />
+    ));
   };
 
   return { handleGetCurPosSuccess, handleGetCurPosFail };

--- a/er-allimi/src/main.jsx
+++ b/er-allimi/src/main.jsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import {
+  QueryClient,
+  QueryClientProvider,
+  QueryCache,
+} from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RecoilRoot } from 'recoil';
 import { router } from './routers';
@@ -13,6 +18,11 @@ const queryClient = new QueryClient({
       refetchOnMount: false,
     },
   },
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      if (query.meta.errorMessage) toast(() => query.meta.errorMessage);
+    },
+  }),
 });
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/er-allimi/yarn.lock
+++ b/er-allimi/yarn.lock
@@ -5149,6 +5149,11 @@ globrex@^0.1.2:
   resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
   integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
+goober@^2.1.10:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/goober/-/goober-2.1.13.tgz#e3c06d5578486212a76c9eba860cbc3232ff6d7c"
+  integrity sha512-jFj3BQeleOoy7t93E9rZ2de+ScC4lQICLwiAQmKMg9F6roKGaLSHoCDYKkWlSafg138jejvq/mTdvmnwDQgqoQ==
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -6880,6 +6885,13 @@ react-element-to-jsx-string@^15.0.0:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "18.1.0"
+
+react-hot-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-hot-toast/-/react-hot-toast-2.4.1.tgz#df04295eda8a7b12c4f968e54a61c8d36f4c0994"
+  integrity sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==
+  dependencies:
+    goober "^2.1.10"
 
 react-icons@^4.10.1:
   version "4.10.1"


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- 사용자 위치 가져오는데 실패할 경우
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/ac55447b-6e45-4877-a549-f5cd8c3cba0e)

- 응급실 목록 데이터를 가져오는데 실패할 경우
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/3a12faa2-ac72-42cd-b1b9-581c9c604678)

- 응급실 실시간 가용 병상 데이터를 가져오는데 실패할 경우
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/04e88c12-1bb5-47f0-a3bd-0c78af94fde2)

## 작업 내용
- 'react-hot-toast' 패키지 설치
- App에 Toaster 컴포넌트 추가
- RefreshButton 컴포넌트 생성
- ErrorMessage 컴포넌트 생성
- queryClient에 queryCache 옵션 추가해 global error 처리
- useGetUserLocation hook에서 에러 발생 시 alert 창 대신 toast 띄우게 수정
- useFetchErList hook에서 에러 발생 시 alert 창 대신 toast 띄우게 수정
- useFetchErsRTavailableBed hook에서 에러 발생 시 alert 창 대신 toast 띄우게 수정

## 논의할 부분