### PR TITLE
[Fix] 가용 병상이 0일 경우도 인포윈도우 생성

### DIFF
--- a/er-allimi/src/components/map/InfoWindowOverlay.jsx
+++ b/er-allimi/src/components/map/InfoWindowOverlay.jsx
@@ -15,7 +15,7 @@ function InfoWindowOverlay({ name, availableBed, totalBed, markerColor }) {
     <div className={styles.infoWindowContainer}>
       <div className={styles.infoWindowContent}>
         <h5 className={styles.hpName}>{name}</h5>
-        {availableBed && totalBed && (
+        {totalBed && (
           <div className={styles.bedData}>
             <BsFillCircleFill size={15} color={markerColor} />
             <div className={styles.bedDataText}>

--- a/er-allimi/src/pages/Map.jsx
+++ b/er-allimi/src/pages/Map.jsx
@@ -90,10 +90,9 @@ function Map() {
       const availableBed = availableBedInfo ? availableBedInfo.hvec : null;
       const totalBed = availableBedInfo ? availableBedInfo.hvs01 : null;
 
-      const markerColor =
-        availableBed && totalBed
-          ? getErRTavailableBedByColor(availableBed, totalBed)
-          : DEFAULT_MARKER_COLOR;
+      const markerColor = totalBed
+        ? getErRTavailableBedByColor(availableBed, totalBed)
+        : DEFAULT_MARKER_COLOR;
 
       const styledMarker = renderToString(
         <ErMarkerOverlay markerColor={markerColor} order={start + idx + 1} />,
@@ -169,8 +168,7 @@ function Map() {
   useEffect(() => {
     createMap();
     // 디테일 페이지인지 확인(해당 병원이 지도 중심으로 가기 위함)
-    const hpIdDetail = getIpFromPathHospitalDetail(location.pathname)
-
+    const hpIdDetail = getIpFromPathHospitalDetail(location.pathname);
   }, [latitude, longitude]);
 
   // 중심 위치 변경 시 응급실 마커, 반경 오버레이 생성


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- [기존] 가용 병상이 0일 경우 인포윈도우 내용에 0만 나옴
- [원인] 
`가용병상 && 전체병상 && 보여줄 컴포넌트`
-[해결]
` 전체병상 && 보여줄 컴포넌트`
map에서 가용병상이 없으면 null값으로 보여줄 컴포넌트 prop으로 들어감.
따라서 컴포넌트에선 전체병상이 true인지 확인하면 됨.

## 논의할 부분