### PR TITLE
[Feat] SuccessMessage 구현 & [Feat] copyText 함수 생성 & [Feat] HpInfoContent 구현

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErItem.jsx
+++ b/er-allimi/src/components/ersBoxes/ErItem.jsx
@@ -4,28 +4,23 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { IoLocationSharp, BiSolidPhone } from '@components';
 import { getPathHospitalDetail, getErRTavailableBedByColor } from '@utils';
+import { copyText } from '@utils';
 
 function ErItem({ item: { hpInfo, availableBedInfo }, order }) {
   const handlePhoneNumberClick = () => {
-    navigator.clipboard
-      .writeText(hpInfo.dutyTel3)
-      .then(() => {
-        alert('응급실 전화번호가 복사되었습니다.');
-      })
-      .catch((err) => {
-        alert('[error] 응급실 전화번호가 복사되지 못했습니다.');
-      });
+    copyText({
+      text: hpInfo.dutyTel3,
+      successMessage: '응급실 전화번호가 복사되었습니다.',
+      errorMessage: '[실패] 응급실 전화번호가 복사되지 못했습니다.',
+    });
   };
 
   const handleAddressClick = () => {
-    navigator.clipboard
-      .writeText(hpInfo.dutyAddr)
-      .then(() => {
-        alert('응급실 주소가 복사되었습니다.');
-      })
-      .catch((err) => {
-        alert('[error] 응급실 주소가 복사되지 못했습니다.');
-      });
+    copyText({
+      text: hpInfo.dutyAddr,
+      successMessage: '응급실 주소가 복사되었습니다.',
+      errorMessage: '[실패] 응급실 주소가 복사되지 못했습니다.',
+    });
   };
 
   return (

--- a/er-allimi/src/components/ersBoxes/SuccessMessage.jsx
+++ b/er-allimi/src/components/ersBoxes/SuccessMessage.jsx
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { BsCheckCircleFill } from '@components';
+
+function SuccessMessage({ content, icon, iconColor }) {
+  return (
+    <StyledSuccessMessage iconColor={iconColor}>
+      {icon}
+      <p>{content}</p>
+    </StyledSuccessMessage>
+  );
+}
+
+const StyledSuccessMessage = styled.div`
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+  color: ${({ theme }) => theme.colors.grayDark};
+
+  svg {
+    margin-right: 0.5rem;
+    font-size: 1.2rem;
+    color: ${({ theme, iconColor }) => theme.colors[iconColor]};
+  }
+
+  p {
+    margin-right: 0.5rem;
+    font-size: inherit;
+  }
+
+  button {
+    font-size: 12px;
+  }
+`;
+
+SuccessMessage.propTypes = {
+  content: PropTypes.string,
+  icon: PropTypes.element,
+  iconColor: PropTypes.oneOf([
+    'gray',
+    'grayDark',
+    'grayDarker',
+    'grayLight',
+    'grayLighter',
+    'red',
+    'redDark',
+    'redDarker',
+    'redLight',
+    'redLighter',
+    'yellow',
+    'yellowDark',
+    'yellowDarker',
+    'yellowLight',
+    'yellowLighter',
+    'green',
+    'greenDark',
+    'greenDarker',
+    'greenLight',
+    'greenLighter',
+  ]),
+  refreshButton: PropTypes.bool,
+};
+
+SuccessMessage.defaultProps = {
+  content: '성공 메시지를 입력해주세요.',
+  icon: <BsCheckCircleFill />,
+  iconColor: 'greenDark',
+};
+
+export default SuccessMessage;

--- a/er-allimi/src/components/ersBoxes/index.js
+++ b/er-allimi/src/components/ersBoxes/index.js
@@ -14,3 +14,4 @@ export { default as SortingButtons } from './SortingButtons';
 export { default as EmptyBox } from './EmptyBox';
 export { default as RefreshButton } from './RefreshButton';
 export { default as ErrorMessage } from './ErrorMessage';
+export { default as SuccessMessage } from './SuccessMessage';

--- a/er-allimi/src/components/hpDetailBoxes/HpInfoBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpInfoBox.jsx
@@ -1,8 +1,12 @@
 import PropTypes from 'prop-types';
-import { Box } from '@components';
+import { Box, HpInfoContent } from '@components';
 
 function HpInfoBox({ className }) {
-  return <Box className={className}>병원 기본정보</Box>;
+  return (
+    <Box className={className}>
+      <HpInfoContent />
+    </Box>
+  );
 }
 
 HpInfoBox.propTypes = {

--- a/er-allimi/src/components/hpDetailBoxes/HpInfoContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpInfoContent.jsx
@@ -1,0 +1,141 @@
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import { IoLocationSharp, BiSolidPhone } from '@components';
+import { copyText } from '@utils';
+
+function HpInfoContent() {
+  // 나중에 hpDetailState selector에서 실 데이터 가져오기
+  const [dutyName, dutyEmclsName, dutyAddr, dutyTel3] = [
+    '서울적십자병원',
+    '지역응급의료기관',
+    '서울특별시 종로구 새문안로 9',
+    '02-2002-8888',
+  ];
+
+  const handlePhoneNumberClick = () => {
+    copyText({
+      text: dutyTel3,
+      successMessage: '응급실 전화번호가 복사되었습니다.',
+      errorMessage: '[실패] 응급실 전화번호가 복사되지 못했습니다.',
+    });
+  };
+
+  const handleAddressClick = () => {
+    copyText({
+      text: dutyAddr,
+      successMessage: '응급실 주소가 복사되었습니다.',
+      errorMessage: '[실패] 응급실 주소가 복사되지 못했습니다.',
+    });
+  };
+
+  return (
+    <StyledHpInfoContent>
+      <HpName>{dutyName}</HpName>
+      <ErClassName>{dutyEmclsName}</ErClassName>
+      <Body>
+        <div>
+          <IoLocationSharp />
+          <p onClick={handleAddressClick}>{dutyAddr}</p>
+        </div>
+        <div>
+          <BiSolidPhone />
+          <p onClick={handlePhoneNumberClick}>{dutyTel3}</p>
+        </div>
+      </Body>
+    </StyledHpInfoContent>
+  );
+}
+
+const StyledHpInfoContent = styled.div`
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.grayLighter};
+  }
+`;
+
+const shortening = css`
+  overflow-x: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  word-break: break-all;
+`;
+
+const HpName = styled.h5`
+  font-size: 14px;
+
+  ${shortening}
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    font-size: 13px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    font-size: 12px;
+  }
+`;
+
+const ErClassName = styled.p`
+  font-size: 11px;
+  color: ${({ theme }) => theme.colors.gray};
+
+  ${shortening}
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    font-size: 10px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    font-size: 9px;
+  }
+`;
+
+const Body = styled.div`
+  margin-top: 0.5rem;
+  width: 100%;
+  line-height: 1.5rem;
+  font-size: 12px;
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    line-height: 1.3rem;
+    font-size: 11px;
+  }
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
+    line-height: 1.2rem;
+    font-size: 10px;
+  }
+
+  svg {
+    margin-right: 0.2rem;
+  }
+
+  p {
+    width: 100%;
+    line-height: inherit;
+    font-size: inherit;
+
+    ${shortening}
+  }
+
+  div {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    font-size: inherit;
+  }
+
+  div:nth-of-type(1) {
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  }
+
+  div:nth-of-type(2) {
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
+    }
+  }
+`;
+
+export default HpInfoContent;

--- a/er-allimi/src/components/hpDetailBoxes/index.js
+++ b/er-allimi/src/components/hpDetailBoxes/index.js
@@ -6,3 +6,4 @@ export { default as HpMessageBox } from './HpMessageBox';
 export { default as HpRtErAvailableBedBox } from './HpRtErAvailableBedBox';
 export { default as HpRtHrAvailableBedBox } from './HpRtHrAvailableBedBox';
 export { default as HpSrIIIBox } from './HpSrIIIBox';
+export { default as HpInfoContent } from './HpInfoContent';

--- a/er-allimi/src/components/icons/index.js
+++ b/er-allimi/src/components/icons/index.js
@@ -14,6 +14,6 @@ export { AiOutlinePlus, AiOutlineMinus } from 'react-icons/ai';
 export { IoLocationSharp, IoCloseSharp } from 'react-icons/io5';
 export { MdOutlineInsertChartOutlined, MdLocationOff } from 'react-icons/md';
 export { VscTriangleDown, VscTriangleUp } from 'react-icons/vsc';
-export { BsFillCircleFill } from 'react-icons/bs';
+export { BsFillCircleFill, BsCheckCircleFill } from 'react-icons/bs';
 export { PiArrowBendUpLeftBold } from 'react-icons/pi';
 export { TbNoteOff, TbHomeOff } from 'react-icons/tb';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -17,6 +17,7 @@ export {
   EmptyBox,
   RefreshButton,
   ErrorMessage,
+  SuccessMessage,
 } from './ersBoxes';
 
 export {
@@ -56,6 +57,7 @@ export {
   TbHomeOff,
   BiSolidError,
   MdLocationOff,
+  BsCheckCircleFill,
 } from './icons';
 
 export {
@@ -76,4 +78,5 @@ export {
   HpRtErAvailableBedBox,
   HpRtHrAvailableBedBox,
   HpSrIIIBox,
+  HpInfoContent,
 } from './hpDetailBoxes';

--- a/er-allimi/src/utils/copyText.jsx
+++ b/er-allimi/src/utils/copyText.jsx
@@ -1,0 +1,15 @@
+import toast from 'react-hot-toast';
+import { SuccessMessage, ErrorMessage } from '@components';
+
+const copyText = ({ text, successMessage, errorMessage }) => {
+  navigator.clipboard
+    .writeText(text)
+    .then(() => {
+      toast(() => <SuccessMessage content={successMessage} />);
+    })
+    .catch((err) => {
+      toast(() => <ErrorMessage content={errorMessage} />);
+    });
+};
+
+export { copyText };

--- a/er-allimi/src/utils/index.js
+++ b/er-allimi/src/utils/index.js
@@ -3,3 +3,4 @@ export { getDistanceFromLocation } from './getDistanceFromLocation';
 export { getErRTavailableBedByColor } from './getErRTavailableBedByColor';
 export { getAddressByCoor } from './getAddressByCoor';
 export { getCoorByAddress } from './getCoorByAddress';
+export { copyText } from './copyText';


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- 응급실 전화번호/주소 복사 성공 시 나타나는 토스트
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/51c0f746-45a4-48d6-8a1a-21cf3efa29e4)
- HpInfoBox
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/62f4632a-d13c-4ff5-a79f-6adb8a62f6fb)

## 작업 내용
- toast에 넣을 SuccessMessage 컴포넌트 구현
- 특정 텍스트를 복사하는 copyText 함수 생성
   - 성공 메시지를 인자로 받아, 복사 성공 시 토스트에 성공 메시지를 띄움
   - 실패 메시지를 인자로 받아, 복사 실패 시 토스트에 실패 메시지를 띄움
- 병원 기본 정보를 담는 HpInfoContent 컴포넌트를 구현해, HpInfoBox에 담음

## 논의할 부분