### PR TITLE
[Feat] hpDetailState 수정 & [Feat] HpInfo 실 데이터 연결 및 가용 병상 데이터 부재 처리

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpInfoContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpInfoContent.jsx
@@ -1,16 +1,19 @@
+import { useRecoilValue } from 'recoil';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { IoLocationSharp, BiSolidPhone } from '@components';
 import { copyText } from '@utils';
+import { hpDetailState } from '@stores';
 
 function HpInfoContent() {
-  // 나중에 hpDetailState selector에서 실 데이터 가져오기
-  const [dutyName, dutyEmclsName, dutyAddr, dutyTel3] = [
-    '서울적십자병원',
-    '지역응급의료기관',
-    '서울특별시 종로구 새문안로 9',
-    '02-2002-8888',
-  ];
+  const hpDetail = useRecoilValue(hpDetailState);
+
+  if (hpDetail.length === 0) return '로딩중...';
+
+  const {
+    hpInfo: { dutyName, dutyEmclsName, dutyAddr, dutyTel3 },
+    HpRTavailableBed,
+  } = hpDetail;
 
   const handlePhoneNumberClick = () => {
     copyText({
@@ -42,6 +45,12 @@ function HpInfoContent() {
           <p onClick={handlePhoneNumberClick}>{dutyTel3}</p>
         </div>
       </Body>
+      {Boolean(HpRTavailableBed) || (
+        <Foot>
+          <p>* 응급실/입원실 가용 병상 정보를 제공하지 않음</p>
+          <p>* 중증응급질환 수술 여부 정보를 제공하지 않음</p>
+        </Foot>
+      )}
     </StyledHpInfoContent>
   );
 }
@@ -135,6 +144,16 @@ const Body = styled.div`
       text-decoration: underline;
       cursor: pointer;
     }
+  }
+`;
+
+const Foot = styled.div`
+  margin-top: 0.5rem;
+
+  p {
+    text-align: right;
+    font-size: 11px;
+    color: ${({ theme }) => theme.colors.gray};
   }
 `;
 

--- a/er-allimi/src/components/ui/Tooltip.jsx
+++ b/er-allimi/src/components/ui/Tooltip.jsx
@@ -11,7 +11,6 @@ function Tooltip({
   className,
 }) {
   let renderContent;
-  console.log(content, typeof content);
   if (typeof content === 'string') renderContent = <p>{content}</p>;
   else if (typeof content === 'object') {
     renderContent = (

--- a/er-allimi/src/stores/selectors/hpDetailState.js
+++ b/er-allimi/src/stores/selectors/hpDetailState.js
@@ -24,12 +24,10 @@ const hpDetailState = selector({
     const [stage1, stage2] = [stages[0], stages[1]];
 
     const hpInfo = {
-      hpInfo: {
-        hpId: targetHpInfoData.hpId,
-        dutyName: targetHpInfoData.dutyName,
-        dutyAddr: targetHpInfoData.dutyAddr,
-        dutyTel3: targetHpInfoData.dutyTel3,
-      },
+      dutyName: targetHpInfoData.dutyName,
+      dutyEmclsName: targetHpInfoData.dutyEmclsName,
+      dutyAddr: targetHpInfoData.dutyAddr,
+      dutyTel3: targetHpInfoData.dutyTel3,
     };
 
     return {


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- HpInfoBox
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/3d0940c5-0ead-40c3-a539-ed59dd8675c1)

## 작업 내용
- hpDetailState selector에서 hpInfo에 hpid 삭제 및 dutyEmclsName 추가
-  Tooltip 콘솔 내 제거
- HpInfoContent를 hpDetailState 데이터와 연결
- 가용 병상 데이터 부재 시, HpInfoContent 하단에 '* 응급실/입원실 가용 병상 정보를 제공하지 않음' 띄우기

## 논의할 부분