### PR TITLE
[Fix] 반경 내 마커를 삭제할 때, 인포윈도우도 같이 삭제

### DIFF
--- a/er-allimi/src/hooks/useMarker.jsx
+++ b/er-allimi/src/hooks/useMarker.jsx
@@ -23,6 +23,7 @@ const useMarker = (map, setupMarkerEventListeners) => {
     const sortedErsPerPage = sortedErsWithRadius.slice(start, end);
 
     const nearByErCount = sortedErsPerPage.length;
+    const newInfowindows = [];
     const newErMarkers = sortedErsPerPage.map((item, idx) => {
       const hpInfo = item.hpInfo;
       const availableBedInfo = item.availableBedInfo;
@@ -63,14 +64,16 @@ const useMarker = (map, setupMarkerEventListeners) => {
         yAnchor: 1,
         zIndex: nearByErCount + 1,
       });
+      newInfowindows.push(newInfoWindow);
       setupMarkerEventListeners(hpInfo.hpid, newInfoWindow);
       return newMarker;
     });
-    //모든 마커 지우기
     setErMarkers(newErMarkers);
+    //모든 마커 지우기
 
     return () => {
       newErMarkers.forEach((marker) => marker.setMap(null));
+      newInfowindows.forEach((infoWindow) => infoWindow.setMap(null));
     };
   }, [map, sortedErsWithRadius, ersPagination]);
 


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- 지동 중심 위치 이동 시, 반경 내 기존 마커들뿐만 아니라 인포윈도우 모두 같이 삭제되게 수정

## 논의할 부분