### PR TITLE
[Feat] Spinner 구현 & [Refactor] EmptyBox 용도 변경 & [Refactor] HpSrIll에서 EmptyBox를 활용해 로딩/에러/데이터부재 처리 & [Refactor] useFetchHpSrIll에 staleTime/cacheTime 추가 

### DIFF
--- a/er-allimi/src/components/ersBoxes/EmptyBox.jsx
+++ b/er-allimi/src/components/ersBoxes/EmptyBox.jsx
@@ -1,10 +1,11 @@
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { TbHomeOff } from '@components';
 
-function EmptyBox() {
+function EmptyBox({ height, icon, children }) {
   return (
-    <StyledEmptyBox>
-      <TbHomeOff />이 위치 주변에는 응급실이 없습니다.
+    <StyledEmptyBox height={height}>
+      <Icon>{icon}</Icon>
+      <Content>{children}</Content>
     </StyledEmptyBox>
   );
 }
@@ -15,14 +16,32 @@ const StyledEmptyBox = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 100px;
+  height: ${({ height }) => `${height}px`};
   color: ${({ theme }) => theme.colors.gray};
-  font-size: 13px;
+`;
 
+const Icon = styled.span`
   svg {
     margin-bottom: 0.5rem;
     font-size: 1.5rem;
+    color: inherit;
   }
 `;
+
+const Content = styled.div`
+  font-size: 13px;
+  color: inherit;
+`;
+
+EmptyBox.propTypes = {
+  height: PropTypes.number, // 단위: px
+  icon: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+};
+
+EmptyBox.defaultProps = {
+  height: 50,
+  children: '내용을 입력하세요.',
+};
 
 export default EmptyBox;

--- a/er-allimi/src/components/ersBoxes/ErsList.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsList.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
 import PropTypes from 'prop-types';
-import { ErItem, EmptyBox } from '@components';
+import { ErItem, EmptyBox, TbHomeOff } from '@components';
 import { sortedErsWithRadiusState, ersPaginationState } from '@stores';
 import { ERS_CNT_PER_PAGE } from '@constants';
 
@@ -20,7 +20,9 @@ function ErsList({ className }) {
 
   const renderErItems =
     dataPerPage.length === 0 ? (
-      <EmptyBox />
+      <EmptyBox height={150} icon={<TbHomeOff />}>
+        이 위치 주변에는 응급실이 없습니다.
+      </EmptyBox>
     ) : (
       dataPerPage.map((item, idx) => {
         return (

--- a/er-allimi/src/components/hpDetailBoxes/HpSrIllContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpSrIllContent.jsx
@@ -1,7 +1,15 @@
 import { useRecoilValue } from 'recoil';
 import styled from '@emotion/styled';
 import { useFetchHpSrIII } from '@hooks';
-import { AdultModel, KidModel, EtcSrIll } from '@components';
+import {
+  AdultModel,
+  KidModel,
+  EtcSrIll,
+  EmptyBox,
+  Spinner,
+  BiError,
+  TbArticleOff,
+} from '@components';
 import { classifySurgery } from '@utils';
 import { hpDetailState } from '@stores';
 
@@ -9,7 +17,12 @@ function HpSriIllContent() {
   const hpDetail = useRecoilValue(hpDetailState);
 
   let content;
-  if (hpDetail.length === 0) content = <div>로딩 중...</div>;
+  if (hpDetail.length === 0)
+    content = (
+      <EmptyBox height={200}>
+        <Spinner />
+      </EmptyBox>
+    );
 
   const { stage1, stage2, hpId } = hpDetail;
   const { data, isLoading, isFetching, isError, error } = useFetchHpSrIII(
@@ -17,8 +30,18 @@ function HpSriIllContent() {
     stage2,
   );
 
-  if (isFetching) content = <div>데이터를 가져오는 중...</div>;
-  else if (isError) content = <div>데이터를 가져오는데 실패함</div>;
+  if (isFetching) {
+    content = (
+      <EmptyBox height={200}>
+        <Spinner />
+      </EmptyBox>
+    );
+  } else if (isError)
+    content = (
+      <EmptyBox height={200} icon={<BiError />}>
+        <Text>데이터를 가져오는데 실패함</Text>
+      </EmptyBox>
+    );
   else {
     const hpData =
       data &&
@@ -27,7 +50,11 @@ function HpSriIllContent() {
         : data);
 
     if (!hpData)
-      content = <div>해당 병원에서는 중증질환 데이터를 제공해주지 않음</div>;
+      content = (
+        <EmptyBox height={200} icon={<TbArticleOff />}>
+          <Text>해당 병원에서는 중증질환 데이터를 제공해주지 않음</Text>
+        </EmptyBox>
+      );
     else {
       const {
         adult: adultData,
@@ -83,6 +110,11 @@ const Models = styled.div`
   justify-items: center;
   align-items: baseline;
   margin-top: 1rem;
+`;
+
+const Text = styled.p`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.gray};
 `;
 
 export default HpSriIllContent;

--- a/er-allimi/src/components/icons/index.js
+++ b/er-allimi/src/components/icons/index.js
@@ -5,6 +5,7 @@ export {
   BiSolidUpArrow,
   BiBody,
   BiSolidError,
+  BiError,
 } from 'react-icons/bi';
 export { GrMapLocation } from 'react-icons/gr';
 export { FaMapMarkedAlt, FaMapMarker, FaBed } from 'react-icons/fa';
@@ -16,4 +17,5 @@ export { MdOutlineInsertChartOutlined, MdLocationOff } from 'react-icons/md';
 export { VscTriangleDown, VscTriangleUp } from 'react-icons/vsc';
 export { BsFillCircleFill, BsCheckCircleFill } from 'react-icons/bs';
 export { PiArrowBendUpLeftBold } from 'react-icons/pi';
-export { TbNoteOff, TbHomeOff } from 'react-icons/tb';
+export { TbNoteOff, TbHomeOff, TbArticleOff } from 'react-icons/tb';
+export { ImSpinner2 } from 'react-icons/im';

--- a/er-allimi/src/components/index.js
+++ b/er-allimi/src/components/index.js
@@ -30,6 +30,7 @@ export {
   MovingBox,
   ClosedBox,
   Tooltip,
+  Spinner,
 } from './ui';
 
 export {
@@ -59,6 +60,9 @@ export {
   BiSolidError,
   MdLocationOff,
   BsCheckCircleFill,
+  ImSpinner2,
+  BiError,
+  TbArticleOff,
 } from './icons';
 
 export {

--- a/er-allimi/src/components/ui/Spinner.jsx
+++ b/er-allimi/src/components/ui/Spinner.jsx
@@ -1,0 +1,61 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/react';
+import { ImSpinner2 } from '@components';
+
+function Spinner({ icon, color }) {
+  return <StyledSpinner color={color}>{icon}</StyledSpinner>;
+}
+
+const rotate = keyframes`
+  0% {
+    transform: rotate(0deg)
+  }
+
+  100% {
+    transform: rotate(360deg)
+  }
+`;
+
+const StyledSpinner = styled.div`
+  display: inline-block;
+  animation: ${rotate} 0.8s linear infinite;
+
+  svg {
+    font-size: 2rem;
+    color: ${({ theme, color }) => theme.colors[color]};
+  }
+`;
+
+Spinner.propTypes = {
+  icon: PropTypes.node,
+  color: PropTypes.oneOf([
+    'gray',
+    'grayDark',
+    'grayDarker',
+    'grayLight',
+    'grayLighter',
+    'red',
+    'redDark',
+    'redDarker',
+    'redLight',
+    'redLighter',
+    'yellow',
+    'yellowDark',
+    'yellowDarker',
+    'yellowLight',
+    'yellowLighter',
+    'green',
+    'greenDark',
+    'greenDarker',
+    'greenLight',
+    'greenLighter',
+  ]),
+};
+
+Spinner.defaultProps = {
+  icon: <ImSpinner2 />,
+  color: 'gray',
+};
+
+export default Spinner;

--- a/er-allimi/src/components/ui/index.js
+++ b/er-allimi/src/components/ui/index.js
@@ -7,3 +7,4 @@ export { default as Toggle } from './Toggle';
 export { default as MovingBox } from './MovingBox';
 export { default as ClosedBox } from './ClosedBox';
 export { default as Tooltip } from './Tooltip';
+export { default as Spinner } from './Spinner';

--- a/er-allimi/src/hooks/useFetchHpSrIII.jsx
+++ b/er-allimi/src/hooks/useFetchHpSrIII.jsx
@@ -11,6 +11,8 @@ function useFetchHpSrIII(stage1, stage2) {
         <ErrorMessage content="[실패] 중증질환 데이터 가져오기" refreshButton />
       ),
     },
+    staleTime: 29 * 60 * 1000, // ms
+    cacheTime: 29 * 60 * 1000, // ms
     retry: 3,
     refetchInterval: 30 * 60 * 1000, // ms
     refetchIntervalInBackground: true,

--- a/er-allimi/src/main.jsx
+++ b/er-allimi/src/main.jsx
@@ -16,6 +16,7 @@ const queryClient = new QueryClient({
     queries: {
       refetchOnWindowFocus: false,
       refetchOnMount: false,
+      refetchOnReconnect: false,
     },
   },
   queryCache: new QueryCache({


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- HpSrIllBox에서 로딩 처리
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/3474fcd6-24e1-4371-b860-6fe731477afa)
- HpSrIllBox에서 에러 처리
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/17072805-5836-48ea-8373-973c93d57595)
- HpSrIllBox에서 데이터 부재 처리
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/2578a0e0-29de-4d14-91fc-22c9ba746676)

## 작업 내용
- Spinner 구현
- 원래 EmptyBox 컴포넌트를 MapView 페이지에서 '내 위치 주변 응급실' 박스 내 응급실이 없을 때 띄우는 용도로 만들었지만, height/icon/children을 props로 받아 특정 height 크기의 빈 컨테이너를 만들고 정중앙에 icon과 children을 위치시키는 용도로 변경
- ErsList에서 EmptyBox 사용 수정
- HpSrIll에서 EmptyBox를 활용해 로딩/에러/데이터부재 처리
- QueryClient에 `refetchOnReconnect: false` 옵션을 추가해 재연결 시에 refetch 해오지 못하게 막음
- useFetchHpSrIll hook에 staleTime/cacheTime 옵션을 추가해 29분동안 fresh 상태로 유지하도록 해 빈번하게 refetch되는 것을 막음

## 논의할 부분