### PR TITLE
[Feat] HpMessage에서 msgDate 실 데이터와 연결

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpMessageItem.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageItem.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { AiTwotoneAlert } from '@components';
+import { getDateStrByHvidate } from '@utils';
 
 function HpMessageItem({
   msgType,
@@ -26,8 +27,8 @@ function HpMessageItem({
         <AiTwotoneAlert />
         <TitleText>{messageType}</TitleText>
         <DateText>
-          {/* ({msgStartDate} ~ {msgEndDate}) */}
-          (2023.08.25 ~ 2023.08.26)
+          ({getDateStrByHvidate(msgStartDate)} ~{' '}
+          {getDateStrByHvidate(msgEndDate)})
         </DateText>
       </Head>
       <ContentText>


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/7ca5f1b5-2d48-42bd-8227-2fa1e472643b)

## 작업 내용
- HpMessage에서 getDateStrByHvidate 함수를 사용해 msgDate 실 데이터와 연결

## 논의할 부분