### PR TITLE
[Feat] HpMessageBox 반응형 처리

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { useState } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 import {
   HpMessageList,
   BiError,
@@ -67,6 +68,12 @@ function HpMessageBox({ className }) {
 
 const StyledMessageBox = styled.div`
   max-width: 300px;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      max-width: 100%;
+    }
+  `}
 `;
 
 const ErrorText = styled.p`

--- a/er-allimi/src/components/hpDetailBoxes/HpMessageItem.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageItem.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 import { AiTwotoneAlert } from '@components';
 import { getDateStrByHvidate } from '@utils';
 
@@ -47,6 +48,12 @@ const Container = styled.div`
   border-radius: 0.1rem;
   background-color: ${({ theme }) => theme.colors.grayDark};
   color: white;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      padding: 0.2rem 0.5rem 0.9rem 0.5rem;
+    }
+  `}
 `;
 
 const Head = styled.div`
@@ -66,16 +73,51 @@ const TitleText = styled.p`
   font-size: 13px;
   font-weight: 600;
   color: inherit;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      font-size: 12px;
+    }
+  `}
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.sm}) {
+      font-size: 11px;
+    }
+  `}
 `;
 
 const DateText = styled.span`
   font-size: 10px;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      font-size: 9px;
+    }
+  `}
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.sm}) {
+      font-size: 8px;
+    }
+  `}
 `;
 
 const ContentText = styled.div`
   grid-row: 2/3;
   grid-column: 2/3;
   font-size: 12px;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      line-height: 15px;
+      font-size: 11px;
+    }
+  `}
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.sm}) {
+      line-height: 14px;
+      font-size: 10px;
+    }
+  `}
 `;
 
 HpMessageItem.propTypes = {

--- a/er-allimi/src/components/hpDetailBoxes/HpMessageList.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageList.jsx
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
 import { HpMessageItem, AutoPlaySlider } from '@components';
 import { classifyMsgSymTyp } from '@utils';
 
@@ -23,14 +25,42 @@ function HpMessageList({ data }) {
   };
 
   return (
-    <AutoPlaySlider
-      data={SlidesData}
-      renderSlide={renderSlide}
-      controllersPosition="top"
-      dotsPosition="top"
-    />
+    <>
+      <AutoPlaySliderAtLg
+        data={SlidesData}
+        renderSlide={renderSlide}
+        controllersPosition="top"
+        dotsPosition="top"
+      />
+      <AutoPlaySliderAtMd
+        data={SlidesData}
+        renderSlide={renderSlide}
+        controllersPosition="bottom"
+        dotsPosition="bottom"
+      />
+    </>
   );
 }
+
+const AutoPlaySliderAtLg = styled(AutoPlaySlider)`
+  display: block;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      display: none;
+    }
+  `}
+`;
+
+const AutoPlaySliderAtMd = styled(AutoPlaySlider)`
+  display: none;
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      display: block;
+    }
+  `}
+`;
 
 HpMessageList.propTypes = {
   data: PropTypes.array,

--- a/er-allimi/src/components/hpDetailBoxes/HpMovingBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMovingBox.jsx
@@ -10,7 +10,9 @@ function HpMovingBox({ className }) {
   const setShowHpMessage = useSetRecoilState(showHpMessageState);
 
   const handleExpand = () => {
-    isExpanded ? setShowHpMessage(false) : setShowHpMessage(true);
+    isExpanded
+      ? setShowHpMessage(false)
+      : setTimeout(() => setShowHpMessage(true), 0.3 * 1000);
     setIsExpanded(!isExpanded);
   };
 

--- a/er-allimi/src/components/ui/AutoPlaySlider.jsx
+++ b/er-allimi/src/components/ui/AutoPlaySlider.jsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import { Slider } from '@components';
 
 function AutoPlaySlider({
+  className,
   data,
   renderSlide,
   control,
@@ -49,7 +50,7 @@ function AutoPlaySlider({
   }, [currentSlide, autoSlider]);
 
   return (
-    <AutoSlider ref={autoSlider}>
+    <AutoSlider ref={autoSlider} className={className}>
       <Slider
         data={data}
         renderSlide={renderSlide}
@@ -76,6 +77,7 @@ const AutoSlider = styled.div`
 `;
 
 AutoPlaySlider.propTypes = {
+  className: PropTypes.string,
   data: PropTypes.array.isRequired,
   renderSlide: PropTypes.func.isRequired,
   control: PropTypes.bool, // controllers 유뮤

--- a/er-allimi/src/components/ui/Slider.jsx
+++ b/er-allimi/src/components/ui/Slider.jsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/react';
 import { HiMiniArrowSmallLeft, HiMiniArrowSmallRight } from '@components';
 
 function Slider({
+  className,
   data,
   renderSlide,
   control,
@@ -119,7 +120,7 @@ function Slider({
     });
 
   return (
-    <SliderContainer>
+    <SliderContainer className={className}>
       <SliderWrap>
         <SlideList
           className="slide-list"
@@ -127,6 +128,7 @@ function Slider({
           dataLength={newData.length}
           sliding={sliding}
           transitionTime={transitionTime}
+          dotsPosition={dotsPosition}
         >
           {renderSlideItems}
         </SlideList>
@@ -172,10 +174,26 @@ const sliding = ({ sliding, transitionTime }) => {
   `;
 };
 
+const slideListAlign = ({ dotsPosition }) => {
+  switch (dotsPosition) {
+    case 'top':
+      return css`
+        align-items: start;
+      `;
+    case 'bottom':
+      return css`
+        align-items: end;
+      `;
+    default:
+      return css`
+        align-items: end;
+      `;
+  }
+};
+
 const SlideList = styled.div`
   display: flex;
-  align-items: top;
-
+  ${slideListAlign}
   ${sliding}
 `;
 
@@ -300,6 +318,7 @@ const DefaultInactiveDot = styled.span`
 `;
 
 Slider.propTypes = {
+  className: PropTypes.string,
   data: PropTypes.array.isRequired,
   renderSlide: PropTypes.func.isRequired,
   control: PropTypes.bool, // controllers 유뮤

--- a/er-allimi/src/pages/HpDetailBoxes.jsx
+++ b/er-allimi/src/pages/HpDetailBoxes.jsx
@@ -21,9 +21,6 @@ function HpDetailBoxes({ className }) {
   const HpRTavailableBedData = useRecoilValue(hpDetailState).HpRTavailableBed;
   return (
     <Container className={className}>
-      <LayoutTop>
-        <StyledCurrentLocationInput />
-      </LayoutTop>
       <LayoutLeft>
         <StyledCurrentLocationBox />
         <StyledHpInfoBox />
@@ -35,11 +32,16 @@ function HpDetailBoxes({ className }) {
         )}
       </LayoutLeft>
       <LayoutRight>
-        {HpRTavailableBedData ? <StyledHpMessageBox /> : <EmptyBox></EmptyBox>}
+        {/* {HpRTavailableBedData ? <StyledHpMessageBox /> : <EmptyBox></EmptyBox>} */}
+        <StyledHpMessageBox />
         <StyledHpSrIIIBox />
       </LayoutRight>
+      <LayoutTop>
+        <StyledCurrentLocationInput />
+        {/* {HpRTavailableBedData && <StyledHpMessageBox />} */}
+        <StyledHpMessageBox />
+      </LayoutTop>
       <LayoutBottom>
-        {HpRTavailableBedData && <StyledHpMessageBox />}
         <StyledErsMovingBox />
       </LayoutBottom>
     </Container>
@@ -48,7 +50,7 @@ function HpDetailBoxes({ className }) {
 
 const EmptyBox = styled.div`
   height: 100px;
-`
+`;
 const Container = styled.div`
   display: grid;
   grid-template-rows: 1fr;
@@ -103,9 +105,9 @@ const LayoutTop = styled.div`
   ${({ theme }) => css`
     @media (max-width: ${theme.breakPoints.md}) {
       display: flex;
+      flex-direction: column;
       justify-content: space-between;
       align-items: start;
-      padding: 1rem;
     }
   `}
 `;
@@ -117,7 +119,6 @@ const LayoutBottom = styled.div`
 
   ${({ theme }) => css`
     @media (max-width: ${theme.breakPoints.md}) {
-      grid-row: 1/3;
       display: flex;
       flex-direction: column;
       justify-content: space-between;
@@ -142,19 +143,25 @@ const zIndexBox = css`
 
 const StyledCurrentLocationInput = styled(CurrentLocationInput)`
   ${zIndexBox}
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      margin: 1rem;
+    }
+  `}
 `;
 
 const StyledCurrentLocationBox = styled(CurrentLocationBox)`
-  margin-bottom: .5rem;
+  margin: 0.5rem;
   ${zIndexBox}
 `;
 
 const StyledHpInfoBox = styled(HpInfoBox)`
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   ${zIndexBox}
 `;
 const StyledHpRtErAvailableBedBox = styled(HpRtErAvailableBedBox)`
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   ${zIndexBox}
 `;
 const StyledHpRtHrAvailableBedBox = styled(HpRtHrAvailableBedBox)`
@@ -165,17 +172,6 @@ const StyledHpSrIIIBox = styled(HpSrIIIBox)`
 `;
 const StyledHpMessageBox = styled(HpMessageBox)`
   ${zIndexBox}
-  ${({ theme }) => css`
-    @media (max-width: ${theme.breakPoints.md}) {
-      margin: 1rem;
-      margin-top: 3.5rem;
-    }
-  `}
-  ${({ theme }) => css`
-    @media (max-width: ${theme.breakPoints.sm}) {
-      display: none;
-    }
-  `}
 `;
 
 const StyledErsMovingBox = styled(HpMovingBox)`


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- md < 화면 너비가 < lg일 때
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/cff21fe7-dbd1-4706-9fea-1dd9d81c1f3d)

- 화면 너비가 md 이하일 때
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/b53d2d4e-f69f-40ee-97cb-c7255f39503b)

## 작업 내용
- Slider에 className prop 추가, dotsPosition에 따라 slideList의 align-items 변경
- AutoPlaySlider에 className prop 추가
- HpMessageItem/HpMessageList/HpMessageBox/HpDetailBoxes 반응형 처리
- HpMovingBox expand시, showHpMessageState atom 변경 지연

## 논의할 부분