### PR TITLE
Feat/scrollbar

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErsContent.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsContent.jsx
@@ -5,6 +5,7 @@ import {
   ErsList,
   RadiusDropdown,
   ErsPagination,
+  ScrollBar,
 } from '@components';
 import { sortedErsWithRadiusState } from '@stores';
 
@@ -41,9 +42,9 @@ function ErsContent() {
     }
   `;
 
-  const StyledErsList = styled(ErsList)`
+  const StyledScrollBar = styled(ScrollBar)`
     height: calc(100% - 100px);
-    overflow-y: scroll;
+    overflow-y: auto;
 
     @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
       height: calc(100% - 100px + 5px);
@@ -73,7 +74,9 @@ function ErsContent() {
         <SortingButtons />
         <StyledRadiusDropdown />
       </Utils>
-      <StyledErsList />
+      <StyledScrollBar>
+        <ErsList />
+      </StyledScrollBar>
       <MarginTopPagination />
     </StyledErsContent>
   );

--- a/er-allimi/src/components/hpDetailBoxes/HpMovingBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMovingBox.jsx
@@ -9,6 +9,7 @@ import {
   HpRtHrAvailableBedContent,
   HpSrIllContent,
   SelectButtons,
+  ScrollBar,
 } from '@components';
 import { showHpMessageState, selectedHpDetailContentState } from '@stores';
 
@@ -32,7 +33,12 @@ function HpMovingBox({ className }) {
 
   const StyledMovingErsBox = styled(MovingBox)`
     height: calc((100vh - 70px) / 2);
-    overflow-y: scroll;
+    /* overflow-y: auto; */
+  `;
+
+  const StyledScrollBar = styled(ScrollBar)`
+    width: 100%;
+    overflow-y: auto;
   `;
 
   const StyledSelectButtons = styled(SelectButtons)`
@@ -45,9 +51,11 @@ function HpMovingBox({ className }) {
       isExpanded={isExpanded}
       handleExpand={handleExpand}
     >
-      <HpInfoContent />
-      <StyledSelectButtons />
-      {renderSelectedContent}
+      <StyledScrollBar>
+        <HpInfoContent />
+        <StyledSelectButtons />
+        {renderSelectedContent}
+      </StyledScrollBar>
     </StyledMovingErsBox>
   );
 }

--- a/er-allimi/src/components/ui/ScrollBar.jsx
+++ b/er-allimi/src/components/ui/ScrollBar.jsx
@@ -86,4 +86,10 @@ ScrollBar.propTypes = {
     'greenLighter',
   ]),
 };
+
+ScrollBar.defaultProps = {
+  scrollBarWidth: 10,
+  scrollBarBackground: 'grayLighter',
+  scrollBarColor: 'grayLight',
+};
 export default ScrollBar;


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/39366835/2376fe4d-b18d-4177-b283-c1674b45b8f7)
![image](https://github.com/ER-allimi/ER-allimi/assets/39366835/b09c75ae-3cca-475c-b953-1f5daaaf261f)
![image](https://github.com/ER-allimi/ER-allimi/assets/39366835/34413a05-ed70-41e5-8c19-1d4f07ccaaf9)

## 작업 내용
- 커스텀 스크롤 바 default props 설정
- 메인 페이지 병원 리스트 박스에 커스텀 스크롤 바 적용(sm,md,lg)
- sm, md 화면일때, 커스텀 스크롤 바 적용

## 논의할 부분