### PR TITLE
[Feat] HpDetail 페이지에선 위치찾기 버튼 안보이게 수정

### DIFF
--- a/er-allimi/src/components/ersBoxes/CurrentLocationBox.jsx
+++ b/er-allimi/src/components/ersBoxes/CurrentLocationBox.jsx
@@ -1,19 +1,26 @@
 import PropTypes from 'prop-types';
+import { useMatch } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { Box, CurrentLocationInput, PostCodeButton } from '@components';
+import { PATH_HOSPITALDETAIL } from '@constants';
 
 function CurrentLocationBox({ className }) {
+  const match = useMatch(PATH_HOSPITALDETAIL);
+  const showBody = !match;
+
   return (
     <Box className={className}>
       <Title>현 위치</Title>
       <CurrentLocationInput />
-      <Body>
-        <Text>
-          현재 자신의 위치 정보가 일치하지 않을경우 <br />
-          위치 찾기에서 주소를 검색하시면 재설정합니다.
-        </Text>
-        <PostCodeButton />
-      </Body>
+      {showBody && (
+        <Body>
+          <Text>
+            현재 자신의 위치 정보가 일치하지 않을경우 <br />
+            위치 찾기에서 주소를 검색하시면 재설정합니다.
+          </Text>
+          <PostCodeButton />
+        </Body>
+      )}
     </Box>
   );
 }

--- a/er-allimi/src/components/ersBoxes/CurrentLocationInput.jsx
+++ b/er-allimi/src/components/ersBoxes/CurrentLocationInput.jsx
@@ -1,11 +1,16 @@
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
+import { useMatch } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { Input, IoLocationSharp, PostCodeButton } from '@components';
 import { userLocationState } from '@stores';
+import { PATH_HOSPITALDETAIL } from '@constants';
 
 function CurrentLocationInput({ className }) {
+  const match = useMatch(PATH_HOSPITALDETAIL);
+  const showPostCodeButton = !match;
+
   const { address } = useRecoilValue(userLocationState);
 
   const [value, setValue] = useState(
@@ -34,12 +39,14 @@ function CurrentLocationInput({ className }) {
     @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
       display: flex;
       padding-right: 0.3rem;
-      width: calc(250px + 10vw);
+      /* width: calc(250px + 10vw); */ // chartView button이 있을 때
+      max-width: calc(100vw - 28px); // chartView button이 없을 때
       box-shadow: 3px 3px 5px 3px ${({ theme }) => theme.colors.grayLight};
     }
 
     @media (max-width: ${({ theme }) => theme.breakPoints.sm}) {
-      max-width: 250px;
+      /* max-width: 250px; */ // chartView button이 있을 때
+      max-width: calc(100vw - 28px); // chartView button이 없을 때
     }
   `;
 
@@ -68,9 +75,11 @@ function CurrentLocationInput({ className }) {
         placeholder="현재 위치"
         leftIcon={<IoLocationSharp />}
         rightIcon={
-          <StyledButton color="gray" round="lg">
-            위치 찾기
-          </StyledButton>
+          showPostCodeButton && (
+            <StyledButton color="gray" round="lg">
+              위치 찾기
+            </StyledButton>
+          )
         }
         color="redLighter"
         round="lg"


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- 메인 페이지 (화면 너비 > lg 일때)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/4cedbf42-6e44-4e76-9ad6-2744eb8e3fab)
- 메인 페이지 (화면 너비 < lg 일때)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/da50c8bb-bf3f-4bcf-b3f8-afbcaac86173)
- 상세 페이지 (화면 너비 > lg 일때)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/678c7703-04a0-4fcc-ad88-1272dbc709e7)
- 상세 페이지 (화면 너비 < lg 일때)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/5e5515d3-a436-45e2-a3c9-8fd547188a91)

## 작업 내용
- HpDetail 페이지에선 현위치 박스에서 위치찾기 버튼 안보이게 수정

## 논의할 부분