### PR TITLE
[Fix] 응급실 가용 병상 정보 없을 경우 가이드 메시지 출력

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpInfoContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpInfoContent.jsx
@@ -11,8 +11,7 @@ function HpInfoContent() {
   if (hpDetail.length === 0) return <Skeleton />;
 
   const {
-    hpInfo: { dutyName, dutyEmclsName, dutyAddr, dutyTel3 },
-    HpRTavailableBed,
+    hpInfo: { dutyName, dutyEmclsName, dutyAddr, dutyTel3 }
   } = hpDetail;
 
   const handlePhoneNumberClick = () => {
@@ -45,12 +44,6 @@ function HpInfoContent() {
           <p onClick={handlePhoneNumberClick}>{dutyTel3}</p>
         </div>
       </Body>
-      {Boolean(HpRTavailableBed) || (
-        <Foot>
-          <p>* 응급실/입원실 가용 병상 정보를 제공하지 않음</p>
-          {/* <p>* 중증응급질환 수술 여부 정보를 제공하지 않음</p> */}
-        </Foot>
-      )}
     </StyledHpInfoContent>
   );
 }
@@ -147,16 +140,6 @@ const Body = styled.div`
       text-decoration: underline;
       cursor: pointer;
     }
-  }
-`;
-
-const Foot = styled.div`
-  margin-top: 0.5rem;
-
-  p {
-    text-align: right;
-    font-size: 11px;
-    color: ${({ theme }) => theme.colors.gray};
   }
 `;
 

--- a/er-allimi/src/components/hpDetailBoxes/HpRtErAvailableBedContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpRtErAvailableBedContent.jsx
@@ -2,10 +2,26 @@ import styled from '@emotion/styled';
 import { hpDetailState } from '@stores';
 import { useRecoilValue } from 'recoil';
 import { getDateStrByHvidate } from '@utils';
-import { ErChart, Tooltip, BsFillInfoSquareFill, Skeleton } from '@components';
+import {
+  ErChart,
+  Tooltip,
+  BsFillInfoSquareFill,
+  Skeleton,
+  EmptyBox,
+  TbArticleOff,
+} from '@components';
 function HpRtErAvailableBedContent() {
   const hpRTavailableBedData = useRecoilValue(hpDetailState);
 
+  if (!hpRTavailableBedData.HpRTavailableBed)
+    return (
+      <>
+        <TitleText>실시간 응급실 가용병상 정보</TitleText>
+        <EmptyBox height={80} icon={<TbArticleOff />}>
+          <Text>해당 병원에서는 응급실 데이터를 제공해주지 않음</Text>
+        </EmptyBox>
+      </>
+    );
   if (hpRTavailableBedData.length === 0) return <Skeleton />;
   const {
     HpRTavailableBed: {
@@ -172,6 +188,10 @@ const YellowCircle = styled(Circle)`
 `;
 const GreenCircle = styled(Circle)`
   background-color: ${({ theme }) => theme.colors.green};
+`;
+const Text = styled.p`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.gray};
 `;
 
 export default HpRtErAvailableBedContent;

--- a/er-allimi/src/components/hpDetailBoxes/HpRtHrAvailableBedContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpRtHrAvailableBedContent.jsx
@@ -2,13 +2,30 @@ import styled from '@emotion/styled';
 import { hpDetailState } from '@stores';
 import { useRecoilValue } from 'recoil';
 import { getDateStrByHvidate, getHpRtHrAvailableBedData } from '@utils';
-import { Button, HpTableItem, ScrollBar, Skeleton } from '@components';
+import {
+  Button,
+  HpTableItem,
+  ScrollBar,
+  Skeleton,
+  EmptyBox,
+  TbArticleOff,
+} from '@components';
 import { useState } from 'react';
+
 function HpRtHrAvailableBedContent() {
   const hpRTavailableBedData = useRecoilValue(hpDetailState);
   const { HpRTavailableBed } = hpRTavailableBedData;
   const [selectedName, setSelectedName] = useState('입원실');
 
+  if (!hpRTavailableBedData.HpRTavailableBed)
+    return (
+      <>
+        <TitleText>실시간 입원실 가용병상 정보</TitleText>
+        <EmptyBox height={80} icon={<TbArticleOff />}>
+          <Text>해당 병원에서는 입원실 데이터를 제공해주지 않음</Text>
+        </EmptyBox>
+      </>
+    );
   if (hpRTavailableBedData.length === 0) return <Skeleton />;
 
   const { hrData, icuData, onlyEmergencyData, etcData } =
@@ -117,16 +134,17 @@ const DateText = styled(CommonText)`
   margin-left: 2px;
   whitespace: 'pre-line';
 `;
-
 const SortButtonContainer = styled.div`
   display: flex;
   gap: 0.5rem;
   margin-bottom: 0.7rem;
 `;
-
 const StyledScrollBar = styled(ScrollBar)`
   max-height: calc(100vh - 590px);
 `;
 const TableContainer = styled.div``;
-
+const Text = styled.p`
+  font-size: 12px;
+  color: ${({ theme }) => theme.colors.gray};
+`;
 export default HpRtHrAvailableBedContent;


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/39366835/28091d9b-e1f6-4ab5-84b5-506ea3269cbe)

## 작업 내용
- 병원 기본 정보 박스에서 응급실 가용 병상 정보 유무 문구 삭제
-  응급실 가용 정보 박스와 입원실 가용 정보 박스에서 정보 유무 가이드 문구 보여줌
-
## 논의할 부분