### PR TITLE
[Refactor] HpDetail 페이지의 url에 stage1, stage2 추가

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErItem.jsx
+++ b/er-allimi/src/components/ersBoxes/ErItem.jsx
@@ -27,6 +27,8 @@ function ErItem({ item: { hpInfo, availableBedInfo }, order }) {
     <StyledErItem>
       <Link
         to={getPathHospitalDetail({
+          stage1: hpInfo.dutyAddr.split(' ')[0],
+          stage2: hpInfo.dutyAddr.split(' ')[1],
           hospitalId: hpInfo.hpid,
         })}
       >

--- a/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
@@ -11,11 +11,12 @@ import {
   Badge,
 } from '@components';
 import { useFetchHpMsg } from '@hooks';
-import { useRecoilValue } from 'recoil';
-import { targetHpIdState, showHpMessageState } from '@stores';
+import { showHpMessageState } from '@stores';
+import { useParams } from 'react-router-dom';
 
 function HpMessageBox({ className }) {
-  const targetHpId = useRecoilValue(targetHpIdState);
+  const targetHpId = useParams().hospitalId;
+
   const { data, isLoading, isError } = useFetchHpMsg(targetHpId);
   const [showHpMessage, setShowHpMessage] = useRecoilState(showHpMessageState);
   const [showLocalHpMessage, setShowLocalHpMessage] = useState(true);

--- a/er-allimi/src/components/hpDetailBoxes/HpSrIllContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpSrIllContent.jsx
@@ -1,4 +1,4 @@
-import { useRecoilValue } from 'recoil';
+import { useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import { useFetchHpSrIII } from '@hooks';
 import {
@@ -11,25 +11,15 @@ import {
   TbArticleOff,
 } from '@components';
 import { classifySurgery } from '@utils';
-import { hpDetailState } from '@stores';
 
 function HpSriIllContent() {
-  const hpDetail = useRecoilValue(hpDetailState);
-
-  let content;
-  if (hpDetail.length === 0)
-    content = (
-      <EmptyBox height={200}>
-        <Spinner />
-      </EmptyBox>
-    );
-
-  const { stage1, stage2, hpId } = hpDetail;
+  const { stage1, stage2, hospitalId: hpId } = useParams();
   const { data, isLoading, isFetching, isError, error } = useFetchHpSrIII(
     stage1,
     stage2,
   );
 
+  let content;
   if (isFetching) {
     content = (
       <EmptyBox height={200}>
@@ -69,11 +59,16 @@ function HpSriIllContent() {
 
       content = (
         <>
-          <Desc>
+          <DescAtLg>
             * 현 병원에서 신체 각 부위에 대한 수술 여부를 노란색으로 나타냈음
             <br />* 노란색 위에 마우스를 올리면, 진행 가능한 수술을 알 수 있음
             <br />* '정보 미제공' 데이터는 표시하지 않음
-          </Desc>
+          </DescAtLg>
+          <DescAtMd>
+            * 현 병원에서 신체 각 부위에 대한 수술 여부를 노란색으로 나타냈음
+            <br />* 노란색 부분을 클릭하면, 진행 가능한 수술을 알 수 있음
+            <br />* '정보 미제공' 데이터는 표시하지 않음
+          </DescAtMd>
           <Models>
             <AdultModel data={adultData} />
             <KidModel data={kidData} />
@@ -100,10 +95,26 @@ const Title = styled.h2`
   margin-bottom: 0.5rem;
 `;
 
-const Desc = styled.p`
+const DescAtLg = styled.p`
+  display: block;
   word-spacing: -1px;
   font-size: 10px;
   color: ${({ theme }) => theme.colors.gray};
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    display: none;
+  }
+`;
+
+const DescAtMd = styled.p`
+  display: none;
+  word-spacing: -1px;
+  font-size: 10px;
+  color: ${({ theme }) => theme.colors.gray};
+
+  @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
+    display: block;
+  }
 `;
 
 const Models = styled.div`

--- a/er-allimi/src/constants/pathes.js
+++ b/er-allimi/src/constants/pathes.js
@@ -1,5 +1,5 @@
 const PATH_ROOT = '/';
 const PATH_CHARTVIEW = '/chartView';
-const PATH_HOSPITALDETAIL = '/hospital/:hospitalId';
+const PATH_HOSPITALDETAIL = '/hospital/:stage1/:stage2/:hospitalId';
 
 export { PATH_ROOT, PATH_CHARTVIEW, PATH_HOSPITALDETAIL };

--- a/er-allimi/src/pages/Map.jsx
+++ b/er-allimi/src/pages/Map.jsx
@@ -68,7 +68,11 @@ function Map() {
     if (!lastElement) return;
 
     lastElement.addEventListener('click', () => {
-      navigate(getPathHospitalDetail({ hospitalId }));
+      const targetHpAddr = ersList.find(
+        (item) => item.hpid === hospitalId,
+      ).dutyAddr;
+      const [stage1, stage2] = targetHpAddr.split(' ');
+      navigate(getPathHospitalDetail({ stage1, stage2, hospitalId }));
     });
 
     lastElement.addEventListener('mouseover', () => {

--- a/er-allimi/src/utils/pathes.js
+++ b/er-allimi/src/utils/pathes.js
@@ -1,3 +1,4 @@
-const getPathHospitalDetail = ({ hospitalId }) => `/hospital/${hospitalId}`;
+const getPathHospitalDetail = ({ stage1, stage2, hospitalId }) =>
+  `/hospital/${stage1}/${stage2}/${hospitalId}`;
 
 export { getPathHospitalDetail };


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/7e28523b-eae4-4ab0-a034-bbe629f0b214)

## 작업 내용
- HpDetail 페이지의 url에 stage1, stage2 추가
- HpMessageBox/HpSrIllContent 컴포넌트에서 recoil의 hpTargetState가 아닌 url에서 직접 params 가져옴
- 지도 마커와 ErsList 박스에서 HpDetail 페이지로 가는 링크 url 수정
## 논의할 부분