### PR TITLE
[Refactor] 뷰포트 md이하일 때, open 아이콘 위치 이동

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpMessageBox.jsx
@@ -116,6 +116,18 @@ const Open = styled.div`
     font-size: 2rem;
     color: black;
   }
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      margin-right: 1.5rem;
+    }
+  `}
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.sm}) {
+      margin-right: 1rem;
+    }
+  `}
 `;
 
 const MsgCntBadge = styled(Badge)`

--- a/er-allimi/src/pages/HpDetailBoxes.jsx
+++ b/er-allimi/src/pages/HpDetailBoxes.jsx
@@ -160,6 +160,12 @@ const StyledHpSrIIIBox = styled(HpSrIIIBox)`
 `;
 const StyledHpMessageBox = styled(HpMessageBox)`
   ${zIndexBox}
+
+  ${({ theme }) => css`
+    @media (max-width: ${theme.breakPoints.md}) {
+      width: 100vw;
+    }
+  `}
 `;
 
 const StyledErsMovingBox = styled(HpMovingBox)`


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/77197774-835f-41b2-80cc-df14cbd36d7a)

## 작업 내용
- 뷰포트 md이하일 때, open 아이콘을 오른쪽으로 위치시킴
## 논의할 부분