### PR TITLE
[Fix] ErList에서 페이지네이션 클릭 후 최상단으로 스크롤 이동

### DIFF
--- a/er-allimi/src/components/ersBoxes/ErsList.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsList.jsx
@@ -15,7 +15,7 @@ function ErsList({ className }) {
 
   useEffect(() => {
     if (ersList.current) {
-      ersList.current.scrollTo(0, 0);
+      ersList.current.scrollIntoView({ block: 'start' });
     }
   }, [page]);
 

--- a/er-allimi/src/pages/NotFoundPage.jsx
+++ b/er-allimi/src/pages/NotFoundPage.jsx
@@ -9,8 +9,6 @@ function NotFoundPage() {
   const navigate = useNavigate();
   const currentPath = useParams();
   const handleBackClick = () => {
-    console.log(currentPath);
-    console.log(currentPath['*']);
     if (currentPath['*'] === 'not-found') {
       navigate(-2);
     } else {


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- ErList에서 페이지네이션 클릭 후 최상단으로 스크롤 이동
- NotFoundPage에 console.log 삭제
## 논의할 부분