### PR TITLE
[Fix] Navbar z-index 설정

### DIFF
--- a/er-allimi/src/components/app/Navbar.jsx
+++ b/er-allimi/src/components/app/Navbar.jsx
@@ -71,6 +71,7 @@ const StyledNavbar = styled.nav`
   align-items: center;
   padding: 1rem;
   background-color: ${({ theme }) => theme.colors.grayDarker};
+  z-index: 101;
 
   ${({ theme }) => css`
     @media (max-width: ${theme.breakPoints.md}) {


### PR DESCRIPTION
## 사진 (구현 캡쳐)
- 수정 전
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/21bcbaeb-e93d-44fe-bdb8-c8503f9d6680)
- 수정 후
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/485a02cc-1919-4fbf-8ba4-c332973c8e71)

## 작업 내용
- 브라우저 너비 md 이하일 때, 네브바가 현 위치 버튼에 가려지는 이슈를 해결하기 위해 `z-index: 101`로 설정
## 논의할 부분