### PR TITLE
[Refactor] React-query onSuccess 콜백 삭제 및 select 옵션으로 전역변수 업데이트

### DIFF
--- a/er-allimi/src/App.jsx
+++ b/er-allimi/src/App.jsx
@@ -12,9 +12,12 @@ import {
 } from '@hooks';
 
 function App() {
-  const { handleGetCurPosSuccess, handleGetCurPosFail } = useGetUserLocation(); // 사용자 위치 정보 가져오기
-  useFetchErList(); // 응급실 전체 목록 정보 가져오기
-  useFetchErsRTavailableBed(); // 응급실 전체 목록 정보 가져오기
+  // 사용자 위치 정보 가져오기
+  const { handleGetCurPosSuccess, handleGetCurPosFail } = useGetUserLocation();
+  // 응급실 전체 목록 정보 가져오기
+  const { isFetching: isErListFetching } = useFetchErList();
+  // 응급실 전체 목록 정보 가져오기
+  const { isFetching: isAvailableBedFetching } = useFetchErsRTavailableBed();
 
   useEffect(() => {
     // 사용자 위치 정보 가져오기
@@ -71,7 +74,7 @@ function App() {
       <StyledApp>
         <Navbar />
         <StyledOutlet>
-          <Outlet />
+          <Outlet context={isErListFetching || isAvailableBedFetching} />
         </StyledOutlet>
       </StyledApp>
       <Toaster position="top-center" reverseOrder={false} />

--- a/er-allimi/src/components/ersBoxes/ErsList.jsx
+++ b/er-allimi/src/components/ersBoxes/ErsList.jsx
@@ -4,14 +4,13 @@ import PropTypes from 'prop-types';
 import { ErItem, EmptyBox, TbHomeOff, Skeleton } from '@components';
 import { sortedErsWithRadiusState, ersPaginationState } from '@stores';
 import { ERS_CNT_PER_PAGE } from '@constants';
-import { useFetchErList, useFetchErsRTavailableBed } from '@hooks';
+import { useOutletContext } from 'react-router-dom';
 
 function ErsList({ className }) {
+  const isFetchingData = useOutletContext()
   const ersList = useRef();
   const data = useRecoilValue(sortedErsWithRadiusState);
   const page = useRecoilValue(ersPaginationState);
-  const { isFetching: isErListFetching } = useFetchErList();
-  const { isFetching: isAvailableBedFetching } = useFetchErsRTavailableBed();
 
   useEffect(() => {
     if (ersList.current) {
@@ -19,7 +18,7 @@ function ErsList({ className }) {
     }
   }, [page]);
 
-  if (isErListFetching || isAvailableBedFetching) {
+  if (isFetchingData) {
     return (
       <>
         <Skeleton isWithAvailableBed={true} />

--- a/er-allimi/src/hooks/useFetchErList.jsx
+++ b/er-allimi/src/hooks/useFetchErList.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getErList } from '@services';
 import { ersListState } from '@stores';
 import { ErrorMessage } from '@components';
+import { useCallback } from 'react';
 
 // 응급실 전체 목록 정보 가져오기
 function useFetchErList() {
@@ -12,9 +13,10 @@ function useFetchErList() {
     queryKey: ['erList'],
     queryFn: getErList,
     retry: 3,
-    onSuccess: (data) => {
-      setErsListState(data);
-    },
+    select:useCallback(
+      (data) => setErsListState(data),
+      []
+    ),
     meta: {
       errorMessage: (
         <ErrorMessage

--- a/er-allimi/src/hooks/useFetchErsRTavailableBed.jsx
+++ b/er-allimi/src/hooks/useFetchErsRTavailableBed.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getErRTavailableBed } from '@services';
 import { ersRTavailableBedState } from '@stores';
 import { ErrorMessage } from '@components';
+import { useCallback } from 'react';
 
 function useFetchErsRTavailableBed() {
   const setErsRTavailableBed = useSetRecoilState(ersRTavailableBedState);
@@ -11,9 +12,7 @@ function useFetchErsRTavailableBed() {
     queryKey: ['ersRTavailableBed'],
     queryFn: () => getErRTavailableBed({ STAGE1: '', STAGE2: '' }),
     retry: 3,
-    onSuccess: (data) => {
-      setErsRTavailableBed(data);
-    },
+    select: useCallback((data) => setErsRTavailableBed(data), []),
     meta: {
       errorMessage: (
         <ErrorMessage


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- React-query onSuccess 콜백 삭제 및 select 옵션으로 전역변수 업데이트
- ErsList에서 isFetching을 확인하기 위해 호출한 useQuery를 삭제하고 router의 context를 사용해서 porps로 isFetching을 내려줌
## 논의할 부분