### PR TITLE
Refactor/error handling

### DIFF
--- a/er-allimi/src/hooks/useMarker.jsx
+++ b/er-allimi/src/hooks/useMarker.jsx
@@ -18,9 +18,6 @@ const useMarker = (map, setupMarkerEventListeners) => {
   useEffect(() => {
     if (!map) return;
 
-    erMarkers.forEach((marker) => marker.setMap(null));
-    setErMarkers([]);
-
     const start = (ersPagination - 1) * ERS_CNT_PER_PAGE;
     const end = ersPagination * ERS_CNT_PER_PAGE;
     const sortedErsPerPage = sortedErsWithRadius.slice(start, end);

--- a/er-allimi/src/hooks/useMarker.jsx
+++ b/er-allimi/src/hooks/useMarker.jsx
@@ -5,6 +5,8 @@ import { ERS_CNT_PER_PAGE } from '@constants';
 import { getErRTavailableBedByColor } from '@utils';
 import { renderToString } from 'react-dom/server';
 import { ErMarkerOverlay, InfoWindowOverlay } from '@components';
+import { Link } from 'react-router-dom';
+import { getPathHospitalDetail } from '@utils';
 const DEFAULT_MARKER_COLOR = '#222222';
 
 const useMarker = (map, setupMarkerEventListeners) => {
@@ -15,6 +17,7 @@ const useMarker = (map, setupMarkerEventListeners) => {
 
   useEffect(() => {
     if (!map) return;
+
     erMarkers.forEach((marker) => marker.setMap(null));
     setErMarkers([]);
 
@@ -26,6 +29,9 @@ const useMarker = (map, setupMarkerEventListeners) => {
     const newInfowindows = [];
     const newErMarkers = sortedErsPerPage.map((item, idx) => {
       const hpInfo = item.hpInfo;
+      const hpId = hpInfo.hpid;
+      const stage1 = hpInfo.dutyAddr.split(' ')[0];
+      const stage2 = hpInfo.dutyAddr.split(' ')[1];
       const availableBedInfo = item.availableBedInfo;
       const name = hpInfo.dutyName;
       const lat = hpInfo.wgs84Lat;
@@ -65,12 +71,12 @@ const useMarker = (map, setupMarkerEventListeners) => {
         zIndex: nearByErCount + 1,
       });
       newInfowindows.push(newInfoWindow);
-      setupMarkerEventListeners(hpInfo.hpid, newInfoWindow);
+      setupMarkerEventListeners(hpId, stage1, stage2,newInfoWindow);
       return newMarker;
     });
     setErMarkers(newErMarkers);
-    //모든 마커 지우기
 
+    //모든 마커 지우기
     return () => {
       newErMarkers.forEach((marker) => marker.setMap(null));
       newInfowindows.forEach((infoWindow) => infoWindow.setMap(null));

--- a/er-allimi/src/pages/HpDetailPage.jsx
+++ b/er-allimi/src/pages/HpDetailPage.jsx
@@ -1,16 +1,28 @@
 import { Map, HpDetailBoxes } from '@pages';
 import styled from '@emotion/styled';
-import { useSetRecoilState } from 'recoil';
-import { targetHpIdState } from '@stores';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { targetHpIdState, ersListState } from '@stores';
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 function HpDetailPage() {
-  const targetHpId = useParams();
+  const { hospitalId, stage1, stage2 } = useParams();
   const setTargetHpId = useSetRecoilState(targetHpIdState);
+  const ersList = useRecoilValue(ersListState);
+  const navigate = useNavigate();
+  const targetStages = `${stage1} ${stage2}`;
+  const targetHp = ersList.find((item) => item.hpid === hospitalId);
+
   useEffect(() => {
-    setTargetHpId(targetHpId.hospitalId);
-  }, [targetHpId]);
+    if (ersList.length === 0) return;
+    const targetHp = ersList.find((item) => item.hpid === hospitalId);
+
+    if (!targetHp || !targetHp.dutyAddr.includes(targetStages)) {
+      navigate('/not-found');
+      return;
+    }
+    setTargetHpId(targetHp.hpid);
+  }, [hospitalId]);
 
   const StyledMapView = styled.div`
     position: relative;
@@ -26,7 +38,7 @@ function HpDetailPage() {
 
   return (
     <StyledMapView>
-      <Map />
+      <Map targetHp={targetHp} />
       <AbsoluteErsBoxes />
     </StyledMapView>
   );

--- a/er-allimi/src/pages/Map.jsx
+++ b/er-allimi/src/pages/Map.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
 import { useEffect, useRef, useState } from 'react';
 import {
   CurrentLocationButton,
@@ -6,8 +7,7 @@ import {
   ZoomOutButton,
   CurrentLocationOverlay,
 } from '@components';
-import { useNavigate, useParams } from 'react-router-dom';
-import { getPathHospitalDetail } from '@utils';
+import { useNavigate } from 'react-router-dom';
 import { renderToString } from 'react-dom/server';
 import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
 import {
@@ -15,18 +15,17 @@ import {
   mapCenterPointState,
   radiusState,
   ersPaginationState,
-  ersListState,
 } from '@stores';
 import { KM_TO_M_UNIT } from '@constants';
 import { useMarker } from '@hooks';
+import { getPathHospitalDetail } from '@utils';
 
 const { kakao } = window;
 
-function Map() {
+function Map({targetHp}) {
   const { latitude, longitude } = useRecoilValue(userLocationState);
   const [centerPoint, setCenterPoint] = useRecoilState(mapCenterPointState);
   const resetPagination = useResetRecoilState(ersPaginationState);
-  const ersList = useRecoilValue(ersListState);
 
   // 지도 표시될 HTML 요소
   const mapContainer = useRef(null);
@@ -34,9 +33,8 @@ function Map() {
   const radius = useRecoilValue(radiusState);
   const defaultCenter = new kakao.maps.LatLng(latitude, longitude);
   const [locPosition, setLocPosition] = useState(defaultCenter);
-  const erMarkers = useMarker(map, setupMarkerEventListeners);
+  const erMarkers = useMarker(map, setupMarkerEventListeners, targetHp);
   const navigate = useNavigate();
-  const hpIdParameter = useParams().hospitalId;
 
   /** 카카오 지도 생성 */
   const createMap = () => {
@@ -61,18 +59,15 @@ function Map() {
   };
 
   /** 마커의 이벤트 리스너 설정 */
-  function setupMarkerEventListeners(hospitalId, infoWindow) {
+  function setupMarkerEventListeners(hpId, stage1, stage2, infoWindow) {
     const markerDiv = document.querySelectorAll('.markerHover');
     const lastElement = markerDiv[markerDiv.length - 1];
 
     if (!lastElement) return;
-
+    
     lastElement.addEventListener('click', () => {
-      const targetHpAddr = ersList.find(
-        (item) => item.hpid === hospitalId,
-      ).dutyAddr;
-      const [stage1, stage2] = targetHpAddr.split(' ');
-      navigate(getPathHospitalDetail({ stage1, stage2, hospitalId }));
+      console.log(hpId)
+      navigate(getPathHospitalDetail({ stage1, stage2, hospitalId:hpId }));
     });
 
     lastElement.addEventListener('mouseover', () => {
@@ -124,13 +119,8 @@ function Map() {
   // 디테일 페이지로 이동 시
   useEffect(() => {
     if (!map) return;
-    if (!hpIdParameter) return;
-    if (ersList.length === 0) return;
-    const targetHp = ersList.find((item) => item.hpid === hpIdParameter);
-    if (!targetHp) {
-      navigate('/not-found');
-      return;
-    }
+    if (!targetHp) return;
+    console.log(targetHp, 'targeHP')
 
     const targetHpPosition = new kakao.maps.LatLng(
       targetHp.wgs84Lat,
@@ -141,7 +131,7 @@ function Map() {
       longitude: targetHp.wgs84Lon,
     });
     map.setCenter(targetHpPosition);
-  }, [map, hpIdParameter]);
+  }, [map, targetHp]);
 
   return (
     <MapContainer ref={mapContainer}>
@@ -153,6 +143,9 @@ function Map() {
     </MapContainer>
   );
 }
+Map.propTypes = {
+  targetHp: PropTypes.object,
+};
 
 const MapContainer = styled.div`
   width: 100%;

--- a/er-allimi/src/services/getErList.js
+++ b/er-allimi/src/services/getErList.js
@@ -14,7 +14,7 @@ const getErList = async function () {
       },
     });
 
-    return res.data.response.body.items?.item;
+    return res.data.response.body.items?.item || [];
   } catch (error) {
     console.error(error);
   }

--- a/er-allimi/src/services/getErRTavailableBed.js
+++ b/er-allimi/src/services/getErRTavailableBed.js
@@ -13,7 +13,7 @@ const getErRTavailableBed = async ({ STAGE1, STAGE2 }) => {
         numOfRows: 522,
       },
     });
-    return response.data.response.body.items?.item;
+    return response.data.response.body.items?.item || [];
   } catch (error) {
     console.error(error);
   }

--- a/er-allimi/src/stores/selectors/hpDetailState.js
+++ b/er-allimi/src/stores/selectors/hpDetailState.js
@@ -16,6 +16,8 @@ const hpDetailState = selector({
       (hpData) => hpData.hpid === targetHpId,
     );
 
+    if (!targetHpInfoData) return [];
+
     const targetHpRTavailableBedData = ersRTavailableBedList.find(
       (hpData) => hpData.hpid === targetHpId,
     );


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- getErList, getErRTavailableBed  api 요청 시 무분별하게 undefined 에러 발생 => undefined 발생 시 [] 반환
- [기존]  Map에서 쿼리스트링 유효성 검사 => HpDetailPage에서 쿼리스트링 유효성 검사 (stage1, stage2, id)
- [기존] 마커 클릭 시 디테일 페이지로 이동 시 erList 전역 변수을 읽어 유효성 검사 후 이동 => useMarker의 data를 활용하여 클릭 이벤트에 prop로 전달함. 불필요한 전역 변수 구독 삭제

## 논의할 부분