### PR TITLE
[Refactor] Theme 인터페이스에 기존 theme 타입 추가, styled 제너릭에 입력한 인터페이스에서 theme 속성 제거

### DIFF
--- a/er-allimi/src/components/ui/Button.tsx
+++ b/er-allimi/src/components/ui/Button.tsx
@@ -52,7 +52,6 @@ const outlined = ({ theme, outline, color }: outlinedProps) =>
   `;
 
 interface StyledButtonProps {
-  theme?: typeof theme;
   round: 'sm' | 'md' | 'lg';
   color: keyof typeof theme.colors;
   outline: boolean;

--- a/er-allimi/src/components/ui/Dropdown.tsx
+++ b/er-allimi/src/components/ui/Dropdown.tsx
@@ -67,11 +67,7 @@ const StyledDropdown = styled.div`
   cursor: pointer;
 `;
 
-interface ThemeProp {
-  theme?: typeof theme;
-}
-
-const Head = styled.div<ThemeProp>`
+const Head = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -88,7 +84,7 @@ const Head = styled.div<ThemeProp>`
   }
 `;
 
-interface BodyProps extends ThemeProp {
+interface BodyProps {
   expanded: boolean;
 }
 
@@ -105,7 +101,7 @@ const Body = styled.div<BodyProps>`
   font-size: inherit;
 `;
 
-const Option = styled.div<ThemeProp>`
+const Option = styled.div`
   padding: 0.2rem 0.5rem;
   border-bottom: 1px solid ${({ theme }) => theme.colors.grayLight};
   font-size: inherit;

--- a/er-allimi/src/components/ui/Input.tsx
+++ b/er-allimi/src/components/ui/Input.tsx
@@ -105,10 +105,7 @@ const container = ({
     }
   `;
 
-// 인터페이스 T에서 U 속성만 optional로 바꿔주는 유틸리티 타입
-type Optional<T, U extends keyof T> = Omit<T, U> & Partial<Pick<T, U>>;
-
-const StyledInput = styled.div<Optional<ContainerProps, 'theme'>>`
+const StyledInput = styled.div<Omit<ContainerProps, 'theme'>>`
   input {
     padding: 0.2rem 0.5rem;
     width: ${({ fullWidth }) => (fullWidth ? '100%' : '300px')};

--- a/er-allimi/src/styles/theme.ts
+++ b/er-allimi/src/styles/theme.ts
@@ -1,3 +1,5 @@
+import '@emotion/react';
+
 const theme = {
   colors: {
     gray: 'rgba(52, 52, 52, 33%)',
@@ -32,5 +34,12 @@ const theme = {
     lg: '1024px', // laptop
   },
 };
+
+// Theme에 타입 추가
+type ThemeTypes = typeof theme;
+
+declare module '@emotion/react' {
+  export interface Theme extends ThemeTypes {}
+}
 
 export { theme };


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- '@emotion/react' 모듈 내에서 export하는 Theme 인터페이스를 extends 키워드를 사용해 기존 theme 타입 전부 추가
- Input, Dropdown, Button 파일에서 `styled.[html요소]`의 제너릭에 입력한 인터페이스에서 theme 속성 타입 제거
## 논의할 부분