### PR TITLE
[Refactor] hooks 폴더 내 일부 파일들 ts로 변환, useQuery의 staleTime/cacheTime을 30초로 변경

### DIFF
--- a/er-allimi/global.d.ts
+++ b/er-allimi/global.d.ts
@@ -1,0 +1,15 @@
+// 한 응급실 데이터
+declare interface erItemType {
+  hpid: string;
+  dutyName: string;
+  dutyEmclsName: string;
+  dutyAddr: string;
+  dutyTel3: string;
+  wgs84Lon: number;
+  wgs84Lat: number;
+}
+
+// 한 응급실의 실시간 가용 병상 데이터
+declare interface erRTavailableBedInfoType {
+  [key: string]: any;
+}

--- a/er-allimi/src/hooks/useFetchErList.tsx
+++ b/er-allimi/src/hooks/useFetchErList.tsx
@@ -13,10 +13,7 @@ function useFetchErList() {
     queryKey: ['erList'],
     queryFn: getErList,
     retry: 3,
-    select:useCallback(
-      (data) => setErsListState(data),
-      []
-    ),
+    select: useCallback((data: erItemType[]) => setErsListState(data), []),
     meta: {
       errorMessage: (
         <ErrorMessage

--- a/er-allimi/src/hooks/useFetchErsRTavailableBed.tsx
+++ b/er-allimi/src/hooks/useFetchErsRTavailableBed.tsx
@@ -12,7 +12,10 @@ function useFetchErsRTavailableBed() {
     queryKey: ['ersRTavailableBed'],
     queryFn: () => getErRTavailableBed({ STAGE1: '', STAGE2: '' }),
     retry: 3,
-    select: useCallback((data) => setErsRTavailableBed(data), []),
+    select: useCallback(
+      (data: erRTavailableBedInfoType[]) => setErsRTavailableBed(data),
+      [],
+    ),
     meta: {
       errorMessage: (
         <ErrorMessage

--- a/er-allimi/src/hooks/useFetchHpMsg.tsx
+++ b/er-allimi/src/hooks/useFetchHpMsg.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getErMsg } from '@services';
 import { ErrorMessage } from '@components';
 
-function useFetchHpMsg(hpId) {
+function useFetchHpMsg(hpId: string) {
   const query = useQuery({
     queryKey: ['erMsg', hpId],
     queryFn: () => getErMsg({ HPID: hpId }),
@@ -14,8 +14,8 @@ function useFetchHpMsg(hpId) {
         />
       ),
     },
-    staleTime: 29 * 60 * 1000, // ms
-    cacheTime: 29 * 60 * 1000, // ms
+    staleTime: 30 * 60 * 1000, // ms
+    cacheTime: 30 * 60 * 1000, // ms
     retry: 3,
     refetchInterval: 30 * 60 * 1000, // ms
     refetchIntervalInBackground: true,

--- a/er-allimi/src/hooks/useFetchHpSrIII.jsx
+++ b/er-allimi/src/hooks/useFetchHpSrIII.jsx
@@ -12,8 +12,8 @@ function useFetchHpSrIII(stage1, stage2, select) {
       ),
     },
     select,
-    staleTime: 29 * 60 * 1000, // ms
-    cacheTime: 29 * 60 * 1000, // ms
+    staleTime: 30 * 60 * 1000, // ms
+    cacheTime: 30 * 60 * 1000, // ms
     retry: 3,
     refetchInterval: 30 * 60 * 1000, // ms
     refetchIntervalInBackground: true,

--- a/er-allimi/src/stores/atoms/ersListState.ts
+++ b/er-allimi/src/stores/atoms/ersListState.ts
@@ -1,15 +1,5 @@
 import { atom } from 'recoil';
 
-interface erItemType {
-  hpid: string;
-  dutyName: string;
-  dutyEmclsName: string;
-  dutyAddr: string;
-  dutyTel3: string;
-  wgs84Lon: number;
-  wgs84Lat: number;
-}
-
 // 전체 응급실 목록
 const ersListState = atom<erItemType[]>({
   key: 'ersListState',

--- a/er-allimi/src/stores/atoms/ersRTavailableBedState.ts
+++ b/er-allimi/src/stores/atoms/ersRTavailableBedState.ts
@@ -1,9 +1,5 @@
 import { atom } from 'recoil';
 
-interface erRTavailableBedInfoType {
-  [key: string]: any;
-}
-
 // 전체 응급실 실시간 가용 병상 목록
 const ersRTavailableBedState = atom<erRTavailableBedInfoType[]>({
   key: 'ersRTavailableBedState',


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- `global.d.ts` 파일 생성
- atoms/ersListState 파일 내 인터페이스를  `global.d.ts`로 옮김
- atoms/ersRTavailableBedState 내 인터페이스를  `global.d.ts`로 옮김
- useFetchErList 파일 ts 변환
- useFetchErsRTavailableBed 파일 ts 변환
- useFetchHpMsg 파일 ts 변환, staleTime/cacheTime을 29 -> 30초로 변경
- useFetchHpSrIll staleTime/cacheTime을 29 -> 30초로 변경
## 논의할 부분