### PR TITLE
[Fix] 실시간 응급실 가용 병상 박스에서 각 chart의 legend 제거

### DIFF
--- a/er-allimi/src/components/hpDetailBoxes/ErChart.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/ErChart.jsx
@@ -31,7 +31,7 @@ function ErChart({ availableBed, totalBed, hpid, title }) {
       },
       size: {
         width: responsiveWidth,
-        height: 100,
+        height: 90,
       },
       legend: {
         item: {
@@ -97,9 +97,6 @@ const Chart = styled.div`
   }
   .bb svg {
     height: 60px;
-    @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
-      height: 70px;
-    }
   }
   .bb-legend-item text {
     font-size: 7px;
@@ -140,11 +137,7 @@ const Chart = styled.div`
     top: 50px;
   }
   .bb-legend {
-    transform: translate(10px, 25px);
-    background-color: red;
-    @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
-      transform: translate(10px, 60px);
-    }
+    display: none;
   }
 `;
 const TitleText = styled.div`

--- a/er-allimi/src/components/hpDetailBoxes/HpRtErAvailableBedContent.jsx
+++ b/er-allimi/src/components/hpDetailBoxes/HpRtErAvailableBedContent.jsx
@@ -136,6 +136,7 @@ const RateGuideText = styled(CommonText)`
 const ChartContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  row-gap: 1rem;
 
   @media (max-width: ${({ theme }) => theme.breakPoints.md}) {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));


### PR DESCRIPTION
## 사진 (구현 캡쳐)
![image](https://github.com/ER-allimi/ER-allimi/assets/98448226/f7f72589-2043-4253-b409-ba2648be75b9)

## 작업 내용
- chart legend 제거(`display: none` 처리)
- bb의 size height를 100 -> 90으로 변경
- chart 간 row-gap 설정
## 논의할 부분
- legend를 chart 하위로 옮겨보려 노력했으나, 마땅한 방법을 찾지 못해 일단 화면 상에 나타나지 않게 했음. 차후 수정 필요.