### PR TITLE
[Refactor] sessionStorage를 사용해 새 탭에 첫 방문 시에만 공지사항 모달창이 뜨도록 수정

### DIFF
--- a/er-allimi/src/components/app/NoticeModal.tsx
+++ b/er-allimi/src/components/app/NoticeModal.tsx
@@ -1,9 +1,16 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { Modal, Button, GrAnnounce } from '@components';
+import { VISITED } from '@constants';
 
 function NoticeModal() {
-  const [showModal, setShowModal] = useState(true);
+  const notVisited = !sessionStorage.getItem(VISITED);
+  const [showModal, setShowModal] = useState(notVisited); // 새로운 탭에 첫 방문 시에만 모달창 띄우기
+
+  useEffect(() => {
+    // 클라이언트 브라우저에 방문 기록 남기기
+    sessionStorage.setItem(VISITED, 'true');
+  }, []);
 
   const handleModalClose = () => {
     setShowModal(false);

--- a/er-allimi/src/constants/index.ts
+++ b/er-allimi/src/constants/index.ts
@@ -26,5 +26,6 @@ export {
   Category,
   BodyPart,
 } from './hpSurgeryClassification';
+export { VISITED } from './sessionStorage';
 
 export type { BodyPartType } from './bodyParts';

--- a/er-allimi/src/constants/sessionStorage.ts
+++ b/er-allimi/src/constants/sessionStorage.ts
@@ -1,0 +1,3 @@
+const VISITED = 'emergencyroomallimi-visited';
+
+export { VISITED };


### PR DESCRIPTION
## 사진 (구현 캡쳐)

## 작업 내용
- VISITED 상수 변수 생성
- sessionStorage를 사용해 새 탭에 첫 방문 시에만 공지사항 모달창이 뜨도록 수정
## 논의할 부분